### PR TITLE
Vesting contract changes

### DIFF
--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -89,7 +89,7 @@ pub fn register_merkle_root(
     }
 
     let mut root_buf: [u8; 32] = [0; 32];
-    match hex::decode_to_slice(merkle_root.to_string(), &mut root_buf) {
+    match hex::decode_to_slice(&merkle_root, &mut root_buf) {
         Ok(()) => {}
         _ => return Err(ContractError::InvalidHexMerkle {}),
     }

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -435,7 +435,7 @@ pub fn assert_new_schedules(
     }
 
     let mut new_counts: BTreeMap<(u64, u64, Uint128), u32> = BTreeMap::new();
-    for schedule in distribution_schedule.clone() {
+    for schedule in distribution_schedule {
         let counter = new_counts.entry(schedule).or_insert(0);
         *counter += 1;
     }

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -24,12 +24,13 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
+anchor-token = { version = "0.3.0", path = "../../packages/anchor_token" }
 cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
+cw20 = { version = "0.8.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-anchor-token = { version = "0.3.0", path = "../../packages/anchor_token" }
+thiserror = "1.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0", default-features = false  }
+cosmwasm-schema = { version = "0.16.0", default-features = false }

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -27,6 +27,7 @@ library = []
 anchor-token = { version = "0.3.0", path = "../../packages/anchor_token" }
 cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
+cw-storage-plus = { version = "0.9", features = ["iterator"] }
 cw20 = { version = "0.8.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/vesting/README.md
+++ b/contracts/vesting/README.md
@@ -1,5 +1,8 @@
 # Vesting
 
-**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/anchor-token/vesting).
+**NOTE**: Reference documentation for this contract is
+available [here](https://docs.anchorprotocol.com/smart-contracts/anchor-token/vesting).
 
-The Vesting Contract contains logic for distributing the token according to the specified vesting schedules for multiple accounts. Each account can have a different vesting schedules, and the accounts can claim a token at any time after the schedule has passed.
+The Vesting Contract contains logic for distributing the token according to the specified vesting schedules for multiple
+accounts. Each account can have a different vesting schedules, and the accounts can claim a token at any time after the
+schedule has passed.

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -2,22 +2,23 @@ use std::cmp::{max, min};
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-
 use cosmwasm_std::{
-    to_binary, Addr, Api, Binary, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, StdResult, Storage, Uint128, WasmMsg,
+    to_binary, Addr, Api, Binary, CanonicalAddr, CosmosMsg, Decimal, Deps, DepsMut, Env,
+    MessageInfo, Response, StdResult, Storage, Uint128, WasmMsg,
 };
+use cw20::Cw20ExecuteMsg;
 
-use crate::state::{
-    read_config, read_vesting_info, read_vesting_infos, store_config, store_vesting_info, Config,
-};
 use anchor_token::common::OrderBy;
 use anchor_token::vesting::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, VestingAccount, VestingAccountResponse,
     VestingAccountsResponse, VestingInfo, VestingSchedule,
-use crate::error::{ContractError, ContractResult};
 };
-use cw20::Cw20ExecuteMsg;
+
+use crate::error::{ContractError, ContractResult};
+use crate::state::{
+    read_config, read_vesting_info, read_vesting_infos, store_config, store_vesting_info,
+    store_vesting_infos, Config,
+};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -191,12 +192,12 @@ fn compute_claim_amount(current_time: u64, vesting_info: &VestingInfo) -> Uint12
 
 fn compute_claim_amounts(
     current_time: u64,
-    vesting_infos: &Vec<(CanonicalAddr, VestingInfo)>,
+    vesting_infos: &[(CanonicalAddr, VestingInfo)],
 ) -> Uint128 {
     vesting_infos
         .iter()
         .map(|p| &p.1)
-        .map(|vi| compute_claim_amount(current_time, &vi))
+        .map(|vi| compute_claim_amount(current_time, vi))
         .fold(Uint128::zero(), |acc, i| acc + i)
 }
 

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -134,8 +134,8 @@ pub fn register_vesting_accounts(
     Ok(Response::new().add_attributes(vec![("action", "register_vesting_accounts")]))
 }
 
-    let current_time = env.block.time.nanos() / 1_000_000_000;
 pub fn claim(deps: DepsMut, env: Env, info: MessageInfo) -> ContractResult<Response> {
+    let current_time = env.block.time.seconds();
     let address = info.sender;
     let address_raw = deps.api.addr_canonicalize(&address.to_string())?;
 

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -232,17 +232,15 @@ pub fn query_vesting_accounts(
     start_after: Option<String>,
     limit: Option<u32>,
     order_by: Option<OrderBy>,
-    let vesting_infos = if let Some(start_after) = start_after {
-        read_vesting_infos(
-            deps.storage,
-            Some(deps.api.addr_canonicalize(&start_after)?),
-            limit,
-            order_by,
-        )?
-    } else {
-        read_vesting_infos(deps.storage, None, limit, order_by)?
-    };
 ) -> ContractResult<VestingAccountsResponse> {
+    let vesting_infos = read_vesting_infos(
+        deps.storage,
+        start_after
+            .map(|s| deps.api.addr_canonicalize(&s))
+            .transpose()?,
+        limit,
+        order_by,
+    )?;
 
     let vesting_account_responses: StdResult<Vec<VestingAccountResponse>> = vesting_infos
         .iter()

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -12,7 +12,7 @@ use crate::state::{
 use anchor_token::common::OrderBy;
 use anchor_token::vesting::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, VestingAccount, VestingAccountResponse,
-    VestingAccountsResponse, VestingInfo,
+    VestingAccountsResponse, VestingInfo, VestingSchedule,
 use crate::error::{ContractError, ContractResult};
 };
 use cw20::Cw20ExecuteMsg;
@@ -98,9 +98,9 @@ pub fn update_config(
     Ok(Response::new().add_attributes(vec![("action", "update_config")]))
 }
 
-fn assert_vesting_schedules(vesting_schedules: &[(u64, u64, Uint128)]) -> ContractResult<()> {
+fn assert_vesting_schedules(vesting_schedules: &[VestingSchedule]) -> ContractResult<()> {
     for vesting_schedule in vesting_schedules.iter() {
-        if vesting_schedule.0 >= vesting_schedule.1 {
+        if vesting_schedule.start_time >= vesting_schedule.end_time {
             return Err(ContractError::InvalidVestingSchedule(
                 "end_time must bigger than start_time".to_string(),
             ));
@@ -261,17 +261,17 @@ pub fn query_vesting_accounts(
 fn test_assert_vesting_schedules() {
     // valid
     assert_vesting_schedules(&[
-        (100u64, 101u64, Uint128::from(100u128)),
-        (100u64, 110u64, Uint128::from(100u128)),
-        (100u64, 200u64, Uint128::from(100u128)),
+        VestingSchedule::new(100u64, 101u64, Uint128::from(100u128)),
+        VestingSchedule::new(100u64, 110u64, Uint128::from(100u128)),
+        VestingSchedule::new(100u64, 200u64, Uint128::from(100u128)),
     ])
     .unwrap();
 
     // invalid
     let res = assert_vesting_schedules(&[
-        (100u64, 100u64, Uint128::from(100u128)),
-        (100u64, 110u64, Uint128::from(100u128)),
-        (100u64, 200u64, Uint128::from(100u128)),
+        VestingSchedule::new(100u64, 100u64, Uint128::from(100u128)),
+        VestingSchedule::new(100u64, 110u64, Uint128::from(100u128)),
+        VestingSchedule::new(100u64, 200u64, Uint128::from(100u128)),
     ]);
     assert_eq!(
         res,

--- a/contracts/vesting/src/error.rs
+++ b/contracts/vesting/src/error.rs
@@ -1,0 +1,19 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+pub type ContractResult<T> = core::result::Result<T, ContractError>;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Cannot withdraw unclaimed refunds - last claim deadline not exceeded")]
+    LastClaimDeadlineNotExceeded,
+
+    #[error("Invalid vesting schedule: {0}")]
+    InvalidVestingSchedule(String),
+}

--- a/contracts/vesting/src/error.rs
+++ b/contracts/vesting/src/error.rs
@@ -14,6 +14,9 @@ pub enum ContractError {
     #[error("Cannot withdraw unclaimed refunds - last claim deadline not exceeded")]
     LastClaimDeadlineNotExceeded,
 
+    #[error("Cannot withdraw refunds - last claim deadline exceeded")]
+    LastClaimDeadlineExceeded,
+
     #[error("Invalid vesting schedule: {0}")]
     InvalidVestingSchedule(String),
 }

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod error;
 pub mod state;
 
 #[cfg(test)]

--- a/contracts/vesting/src/state.rs
+++ b/contracts/vesting/src/state.rs
@@ -70,20 +70,6 @@ pub fn read_vesting_infos(
         .collect()
 }
 
-pub fn store_vesting_infos(
-    storage: &mut dyn Storage,
-    vesting_infos: Vec<(CanonicalAddr, VestingInfo)>,
-) -> StdResult<()> {
-    for entry in vesting_infos {
-        match VESTING_INFO.save(storage, entry.0.as_slice(), &entry.1) {
-            Ok(_) => continue,
-            Err(e) => return Err(e),
-        }
-    }
-
-    Ok(())
-}
-
 // this will set the first key after the provided key, by appending a 1 byte
 fn calc_range_start_addr(start_after: Option<CanonicalAddr>) -> Option<Vec<u8>> {
     start_after.map(|addr| {

--- a/contracts/vesting/src/state.rs
+++ b/contracts/vesting/src/state.rs
@@ -17,7 +17,7 @@ pub struct Config {
     pub last_claim_deadline: u64,
 }
 
-pub fn save_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {
+pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {
     CONFIG.save(storage, config)
 }
 

--- a/contracts/vesting/src/state.rs
+++ b/contracts/vesting/src/state.rs
@@ -1,31 +1,32 @@
+use cosmwasm_std::{CanonicalAddr, Order, StdResult, Storage};
+use cw_storage_plus::{Bound, Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use anchor_token::common::OrderBy;
 use anchor_token::vesting::VestingInfo;
-use cosmwasm_std::{CanonicalAddr, StdResult, Storage};
-use cosmwasm_storage::{bucket, bucket_read, singleton, singleton_read, ReadonlyBucket};
 
-const KEY_CONFIG: &[u8] = b"config";
-const PREFIX_KEY_VESTING_INFO: &[u8] = b"vesting_info";
+const CONFIG: Item<Config> = Item::new("config");
+const VESTING_INFO: Map<&[u8], VestingInfo> = Map::new("vesting_info");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub owner: CanonicalAddr,
     pub anchor_token: CanonicalAddr,
     pub genesis_time: u64,
+    pub last_claim_deadline: u64,
 }
 
-pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {
-    singleton::<Config>(storage, KEY_CONFIG).save(config)
+pub fn save_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {
+    CONFIG.save(storage, config)
 }
 
 pub fn read_config(storage: &dyn Storage) -> StdResult<Config> {
-    singleton_read::<Config>(storage, KEY_CONFIG).load()
+    CONFIG.load(storage)
 }
 
 pub fn read_vesting_info(storage: &dyn Storage, address: &CanonicalAddr) -> StdResult<VestingInfo> {
-    bucket_read::<VestingInfo>(storage, PREFIX_KEY_VESTING_INFO).load(address.as_slice())
+    VESTING_INFO.load(storage, address.as_slice())
 }
 
 pub fn store_vesting_info(
@@ -33,28 +34,34 @@ pub fn store_vesting_info(
     address: &CanonicalAddr,
     vesting_info: &VestingInfo,
 ) -> StdResult<()> {
-    bucket::<VestingInfo>(storage, PREFIX_KEY_VESTING_INFO).save(address.as_slice(), vesting_info)
+    VESTING_INFO.save(storage, address.as_slice(), vesting_info)
 }
 
 const MAX_LIMIT: u32 = 30;
 const DEFAULT_LIMIT: u32 = 10;
-pub fn read_vesting_infos<'a>(
-    storage: &'a dyn Storage,
+
+pub fn read_vesting_infos(
+    storage: &dyn Storage,
     start_after: Option<CanonicalAddr>,
     limit: Option<u32>,
     order_by: Option<OrderBy>,
 ) -> StdResult<Vec<(CanonicalAddr, VestingInfo)>> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let (start, end, order_by) = match order_by {
-        Some(OrderBy::Asc) => (calc_range_start_addr(start_after), None, OrderBy::Asc),
-        _ => (None, calc_range_end_addr(start_after), OrderBy::Desc),
+    let (start, end, order) = match order_by {
+        Some(OrderBy::Desc) => (
+            None,
+            calc_range_end_addr(start_after).map(Bound::exclusive),
+            Order::Descending,
+        ),
+        _ => (
+            calc_range_start_addr(start_after).map(Bound::inclusive),
+            None,
+            Order::Ascending,
+        ),
     };
 
-    let vesting_accounts: ReadonlyBucket<'a, VestingInfo> =
-        ReadonlyBucket::new(storage, PREFIX_KEY_VESTING_INFO);
-
-    vesting_accounts
-        .range(start.as_deref(), end.as_deref(), order_by.into())
+    VESTING_INFO
+        .range(storage, start, end, order)
         .take(limit)
         .map(|item| {
             let (k, v) = item?;

--- a/contracts/vesting/src/state.rs
+++ b/contracts/vesting/src/state.rs
@@ -70,6 +70,20 @@ pub fn read_vesting_infos(
         .collect()
 }
 
+pub fn store_vesting_infos(
+    storage: &mut dyn Storage,
+    vesting_infos: Vec<(CanonicalAddr, VestingInfo)>,
+) -> StdResult<()> {
+    for entry in vesting_infos {
+        match VESTING_INFO.save(storage, entry.0.as_slice(), &entry.1) {
+            Ok(_) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}
+
 // this will set the first key after the provided key, by appending a 1 byte
 fn calc_range_start_addr(start_after: Option<CanonicalAddr>) -> Option<Vec<u8>> {
     start_after.map(|addr| {

--- a/contracts/vesting/src/tests.rs
+++ b/contracts/vesting/src/tests.rs
@@ -11,6 +11,7 @@ use cosmwasm_std::{
     Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
+use crate::error::ContractError;
 
 #[test]
 fn proper_initialization() {
@@ -78,10 +79,7 @@ fn update_config() {
     };
     let info = mock_info("owner", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg);
-    match res {
-        Err(StdError::GenericErr { msg, .. }) => assert_eq!(msg, "unauthorized"),
-        _ => panic!("DO NOT ENTER HERE"),
-    }
+    assert_eq!(res, Err(ContractError::Unauthorized));
 
     let msg = ExecuteMsg::UpdateConfig {
         owner: None,
@@ -166,10 +164,7 @@ fn register_vesting_accounts() {
     };
     let info = mock_info("addr0000", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg.clone());
-    match res {
-        Err(StdError::GenericErr { msg, .. }) => assert_eq!(msg, "unauthorized"),
-        _ => panic!("DO NOT ENTER HERE"),
-    }
+    assert_eq!(res, Err(ContractError::Unauthorized));
 
     let info = mock_info("owner", &[]);
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/vesting/src/tests.rs
+++ b/contracts/vesting/src/tests.rs
@@ -1,16 +1,14 @@
-use crate::contract::{execute, instantiate, query};
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{attr, from_binary, to_binary, CosmosMsg, SubMsg, Timestamp, Uint128, WasmMsg};
+use cw20::Cw20ExecuteMsg;
+
 use anchor_token::common::OrderBy;
 use anchor_token::vesting::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, VestingAccount, VestingAccountResponse,
     VestingAccountsResponse, VestingInfo, VestingSchedule,
 };
 
-use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{
-    attr, from_binary, to_binary, Api, CanonicalAddr, CosmosMsg, StdError, SubMsg, Timestamp,
-    Uint128, WasmMsg,
-};
-use cw20::Cw20ExecuteMsg;
+use crate::contract::{execute, instantiate, query};
 use crate::error::ContractError;
 
 #[test]
@@ -390,7 +388,7 @@ fn unclaimed() {
     let msg = ExecuteMsg::RegisterVestingAccounts {
         vesting_accounts: vec![
             VestingAccount {
-                address: acct1.clone(),
+                address: acct1,
                 schedules: vec![
                     VestingSchedule::new(100u64, 101u64, Uint128::new(100u128)),
                     VestingSchedule::new(100u64, 110u64, Uint128::new(100u128)),
@@ -398,11 +396,11 @@ fn unclaimed() {
                 ],
             },
             VestingAccount {
-                address: acct2.clone(),
+                address: acct2,
                 schedules: vec![VestingSchedule::new(100u64, 110u64, Uint128::new(100u128))],
             },
             VestingAccount {
-                address: acct3.clone(),
+                address: acct3,
                 schedules: vec![VestingSchedule::new(100u64, 200u64, Uint128::new(100u128))],
             },
         ],

--- a/contracts/vesting/src/tests.rs
+++ b/contracts/vesting/src/tests.rs
@@ -196,8 +196,50 @@ fn register_vesting_accounts() {
                             VestingSchedule::new(100u64, 110u64, Uint128::new(100u128)),
                             VestingSchedule::new(100u64, 200u64, Uint128::new(100u128)),
                         ],
-                    }
+                    },
                 },
+                VestingAccountResponse {
+                    address: acct2.clone(),
+                    info: VestingInfo {
+                        last_claim_time: 100u64,
+                        schedules: vec![VestingSchedule::new(
+                            100u64,
+                            110u64,
+                            Uint128::new(100u128),
+                        )],
+                    },
+                },
+                VestingAccountResponse {
+                    address: acct3.clone(),
+                    info: VestingInfo {
+                        last_claim_time: 100u64,
+                        schedules: vec![VestingSchedule::new(
+                            100u64,
+                            200u64,
+                            Uint128::new(100u128),
+                        )],
+                    },
+                },
+            ]
+        }
+    );
+
+    assert_eq!(
+        from_binary::<VestingAccountsResponse>(
+            &query(
+                deps.as_ref(),
+                mock_env(),
+                QueryMsg::VestingAccounts {
+                    limit: None,
+                    start_after: Some(acct3),
+                    order_by: Some(OrderBy::Desc),
+                },
+            )
+            .unwrap()
+        )
+        .unwrap(),
+        VestingAccountsResponse {
+            vesting_accounts: vec![
                 VestingAccountResponse {
                     address: acct2,
                     info: VestingInfo {
@@ -210,7 +252,7 @@ fn register_vesting_accounts() {
                     },
                 },
                 VestingAccountResponse {
-                    address: acct3,
+                    address: acct1,
                     info: VestingInfo {
                         last_claim_time: 100u64,
                         schedules: vec![

--- a/contracts/vesting/src/tests.rs
+++ b/contracts/vesting/src/tests.rs
@@ -2,7 +2,7 @@ use crate::contract::{execute, instantiate, query};
 use anchor_token::common::OrderBy;
 use anchor_token::vesting::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg, VestingAccount, VestingAccountResponse,
-    VestingAccountsResponse, VestingInfo,
+    VestingAccountsResponse, VestingInfo, VestingSchedule,
 };
 
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
@@ -115,50 +115,28 @@ fn register_vesting_accounts() {
     let info = mock_info("addr0000", &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    let acct1 = deps
-        .api
-        .addr_humanize(&CanonicalAddr::from(vec![
-            1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ]))
-        .unwrap()
-        .to_string();
-
-    let acct2 = deps
-        .api
-        .addr_humanize(&CanonicalAddr::from(vec![
-            1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ]))
-        .unwrap()
-        .to_string();
-
-    let acct3 = deps
-        .api
-        .addr_humanize(&CanonicalAddr::from(vec![
-            1, 1, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ]))
-        .unwrap()
-        .to_string();
+    let acct0 = "acct0000".to_string();
+    let acct1 = "acct0001".to_string();
+    let acct2 = "acct0002".to_string();
+    let acct3 = "acct0003".to_string();
 
     let msg = ExecuteMsg::RegisterVestingAccounts {
         vesting_accounts: vec![
             VestingAccount {
                 address: acct1.clone(),
                 schedules: vec![
-                    (100u64, 101u64, Uint128::from(100u128)),
-                    (100u64, 110u64, Uint128::from(100u128)),
-                    (100u64, 200u64, Uint128::from(100u128)),
+                    VestingSchedule::new(100u64, 101u64, Uint128::new(100u128)),
+                    VestingSchedule::new(100u64, 110u64, Uint128::new(100u128)),
+                    VestingSchedule::new(100u64, 200u64, Uint128::new(100u128)),
                 ],
             },
             VestingAccount {
                 address: acct2.clone(),
-                schedules: vec![(100u64, 110u64, Uint128::from(100u128))],
+                schedules: vec![VestingSchedule::new(100u64, 110u64, Uint128::new(100u128))],
             },
             VestingAccount {
                 address: acct3.clone(),
-                schedules: vec![(100u64, 200u64, Uint128::from(100u128))],
+                schedules: vec![VestingSchedule::new(100u64, 200u64, Uint128::new(100u128))],
             },
         ],
     };
@@ -185,9 +163,9 @@ fn register_vesting_accounts() {
             info: VestingInfo {
                 last_claim_time: 100u64,
                 schedules: vec![
-                    (100u64, 101u64, Uint128::from(100u128)),
-                    (100u64, 110u64, Uint128::from(100u128)),
-                    (100u64, 200u64, Uint128::from(100u128)),
+                    VestingSchedule::new(100u64, 101u64, Uint128::new(100u128)),
+                    VestingSchedule::new(100u64, 110u64, Uint128::new(100u128)),
+                    VestingSchedule::new(100u64, 200u64, Uint128::new(100u128)),
                 ],
             }
         }
@@ -210,13 +188,13 @@ fn register_vesting_accounts() {
         VestingAccountsResponse {
             vesting_accounts: vec![
                 VestingAccountResponse {
-                    address: acct1,
+                    address: acct1.clone(),
                     info: VestingInfo {
                         last_claim_time: 100u64,
                         schedules: vec![
-                            (100u64, 101u64, Uint128::from(100u128)),
-                            (100u64, 110u64, Uint128::from(100u128)),
-                            (100u64, 200u64, Uint128::from(100u128)),
+                            VestingSchedule::new(100u64, 101u64, Uint128::new(100u128)),
+                            VestingSchedule::new(100u64, 110u64, Uint128::new(100u128)),
+                            VestingSchedule::new(100u64, 200u64, Uint128::new(100u128)),
                         ],
                     }
                 },
@@ -224,16 +202,24 @@ fn register_vesting_accounts() {
                     address: acct2,
                     info: VestingInfo {
                         last_claim_time: 100u64,
-                        schedules: vec![(100u64, 110u64, Uint128::from(100u128))],
-                    }
+                        schedules: vec![VestingSchedule::new(
+                            100u64,
+                            110u64,
+                            Uint128::new(100u128),
+                        )],
+                    },
                 },
                 VestingAccountResponse {
                     address: acct3,
                     info: VestingInfo {
                         last_claim_time: 100u64,
-                        schedules: vec![(100u64, 200u64, Uint128::from(100u128))],
-                    }
-                }
+                        schedules: vec![
+                            VestingSchedule::new(100u64, 101u64, Uint128::new(100u128)),
+                            VestingSchedule::new(100u64, 110u64, Uint128::new(100u128)),
+                            VestingSchedule::new(100u64, 200u64, Uint128::new(100u128)),
+                        ],
+                    },
+                },
             ]
         }
     );
@@ -256,9 +242,9 @@ fn claim() {
         vesting_accounts: vec![VestingAccount {
             address: "addr0000".to_string(),
             schedules: vec![
-                (100u64, 101u64, Uint128::from(100u128)),
-                (100u64, 110u64, Uint128::from(100u128)),
-                (100u64, 200u64, Uint128::from(100u128)),
+                VestingSchedule::new(100u64, 101u64, Uint128::new(100u128)),
+                VestingSchedule::new(100u64, 110u64, Uint128::new(100u128)),
+                VestingSchedule::new(100u64, 200u64, Uint128::new(100u128)),
             ],
         }],
     };

--- a/packages/anchor_token/src/vesting.rs
+++ b/packages/anchor_token/src/vesting.rs
@@ -1,8 +1,8 @@
+use cosmwasm_std::Uint128;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::common::OrderBy;
-use cosmwasm_std::Uint128;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {

--- a/packages/anchor_token/src/vesting.rs
+++ b/packages/anchor_token/src/vesting.rs
@@ -9,6 +9,7 @@ pub struct InstantiateMsg {
     pub owner: String,
     pub anchor_token: String,
     pub genesis_time: u64,
+    pub last_claim_deadline: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -18,11 +19,13 @@ pub enum ExecuteMsg {
         owner: Option<String>,
         anchor_token: Option<String>,
         genesis_time: Option<u64>,
+        last_claim_deadline: Option<u64>,
     },
     RegisterVestingAccounts {
         vesting_accounts: Vec<VestingAccount>,
     },
     Claim {},
+    WithdrawUnclaimed {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -74,6 +77,7 @@ pub struct ConfigResponse {
     pub owner: String,
     pub anchor_token: String,
     pub genesis_time: u64,
+    pub last_claim_deadline: u64,
 }
 
 // We define a custom struct for each query response

--- a/packages/anchor_token/src/vesting.rs
+++ b/packages/anchor_token/src/vesting.rs
@@ -85,6 +85,7 @@ pub struct ConfigResponse {
 pub struct VestingAccountResponse {
     pub address: String,
     pub info: VestingInfo,
+    pub accrued_anc: Uint128,
 }
 
 // We define a custom struct for each query response
@@ -92,3 +93,6 @@ pub struct VestingAccountResponse {
 pub struct VestingAccountsResponse {
     pub vesting_accounts: Vec<VestingAccountResponse>,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrateMsg {}

--- a/packages/anchor_token/src/vesting.rs
+++ b/packages/anchor_token/src/vesting.rs
@@ -25,17 +25,33 @@ pub enum ExecuteMsg {
     Claim {},
 }
 
-/// CONTRACT: end_time > start_time
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VestingAccount {
     pub address: String,
-    pub schedules: Vec<(u64, u64, Uint128)>,
+    pub schedules: Vec<VestingSchedule>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VestingInfo {
-    pub schedules: Vec<(u64, u64, Uint128)>,
+    pub schedules: Vec<VestingSchedule>,
     pub last_claim_time: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct VestingSchedule {
+    pub start_time: u64,
+    pub end_time: u64,
+    pub amount: Uint128,
+}
+
+impl VestingSchedule {
+    pub fn new(start_time: u64, end_time: u64, amount: Uint128) -> VestingSchedule {
+        VestingSchedule {
+            start_time,
+            end_time,
+            amount,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
- Use second-based timestamps
- Support withdrawing unclaimed rewards after the last deadline has passed

and some refactoring, cleanups etc.