### PR TITLE
feat: veANC - Gauge Controller

### DIFF
--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -89,7 +89,7 @@ pub fn register_merkle_root(
     }
 
     let mut root_buf: [u8; 32] = [0; 32];
-    match hex::decode_to_slice(merkle_root.to_string(), &mut root_buf) {
+    match hex::decode_to_slice(&merkle_root, &mut root_buf) {
         Ok(()) => {}
         _ => return Err(ContractError::InvalidHexMerkle {}),
     }

--- a/contracts/gauge_controller/.cargo/config
+++ b/contracts/gauge_controller/.cargo/config
@@ -1,0 +1,5 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+integration-test = "test --test integration"
+schema = "run --example schema"

--- a/contracts/gauge_controller/.editorconfig
+++ b/contracts/gauge_controller/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4

--- a/contracts/gauge_controller/.gitignore
+++ b/contracts/gauge_controller/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+*.iml
+.idea

--- a/contracts/gauge_controller/Cargo.toml
+++ b/contracts/gauge_controller/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "anchor-gauge-controller"
+version = "0.0.0"
+authors = ["Terraform Labs, PTE."]
+edition = "2018"
+license = "Apache-2.0"
+description = "Gauge Controller - @TODO"
+repository = "https://github.com/Anchor-Protocol/anchor-token-contracts"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for quicker tests, cargo test --lib
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+
+[dependencies]
+cw20 = { version = "0.8.0" } 
+cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
+anchor-token = { version = "0.3.0", path = "../../packages/anchor_token" }
+schemars = "0.8.1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+astroport = "0.3.1"
+thiserror = { version = "1.0.20" }
+hex = "0.4"
+
+[dev-dependencies]
+cosmwasm-schema = "0.16.0"

--- a/contracts/gauge_controller/Cargo.toml
+++ b/contracts/gauge_controller/Cargo.toml
@@ -35,15 +35,12 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.8.0" } 
 cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
-cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 anchor-token = { version = "0.3.0", path = "../../packages/anchor_token" }
+cw-storage-plus = { version = "0.8.0", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-astroport = "0.3.1"
 thiserror = { version = "1.0.20" }
-hex = "0.4"
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.0"

--- a/contracts/gauge_controller/README.md
+++ b/contracts/gauge_controller/README.md
@@ -1,0 +1,3 @@
+# Gauge Controller
+
+@TODO

--- a/contracts/gauge_controller/examples/schema.rs
+++ b/contracts/gauge_controller/examples/schema.rs
@@ -1,0 +1,22 @@
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use anchor_token::gauge_controller::{
+    ExecuteMsg, GaugeWeightResponse, InstantiateMsg, QueryMsg, RelativeWeightResponse,
+    TotalWeightResponse,
+};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(GaugeWeightResponse), &out_dir);
+    export_schema(&schema_for!(TotalWeightResponse), &out_dir);
+    export_schema(&schema_for!(RelativeWeightResponse), &out_dir);
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+}

--- a/contracts/gauge_controller/examples/schema.rs
+++ b/contracts/gauge_controller/examples/schema.rs
@@ -3,8 +3,8 @@ use std::env::current_dir;
 use std::fs::create_dir_all;
 
 use anchor_token::gauge_controller::{
-    ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeWeightResponse, InstantiateMsg,
-    NGaugesResponse, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
+    AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
+    GaugeWeightResponse, InstantiateMsg, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
 };
 
 fn main() {
@@ -16,8 +16,9 @@ fn main() {
     export_schema(&schema_for!(GaugeWeightResponse), &out_dir);
     export_schema(&schema_for!(TotalWeightResponse), &out_dir);
     export_schema(&schema_for!(RelativeWeightResponse), &out_dir);
-    export_schema(&schema_for!(NGaugesResponse), &out_dir);
+    export_schema(&schema_for!(GaugeCountResponse), &out_dir);
     export_schema(&schema_for!(GaugeAddrResponse), &out_dir);
+    export_schema(&schema_for!(AllGaugeAddrResponse), &out_dir);
     export_schema(&schema_for!(ConfigResponse), &out_dir);
     export_schema(&schema_for!(InstantiateMsg), &out_dir);
     export_schema(&schema_for!(ExecuteMsg), &out_dir);

--- a/contracts/gauge_controller/examples/schema.rs
+++ b/contracts/gauge_controller/examples/schema.rs
@@ -3,8 +3,8 @@ use std::env::current_dir;
 use std::fs::create_dir_all;
 
 use anchor_token::gauge_controller::{
-    ExecuteMsg, GaugeWeightResponse, InstantiateMsg, QueryMsg, RelativeWeightResponse,
-    TotalWeightResponse,
+    ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeWeightResponse, InstantiateMsg,
+    NGaugesResponse, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
 };
 
 fn main() {
@@ -16,6 +16,9 @@ fn main() {
     export_schema(&schema_for!(GaugeWeightResponse), &out_dir);
     export_schema(&schema_for!(TotalWeightResponse), &out_dir);
     export_schema(&schema_for!(RelativeWeightResponse), &out_dir);
+    export_schema(&schema_for!(NGaugesResponse), &out_dir);
+    export_schema(&schema_for!(GaugeAddrResponse), &out_dir);
+    export_schema(&schema_for!(ConfigResponse), &out_dir);
     export_schema(&schema_for!(InstantiateMsg), &out_dir);
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);

--- a/contracts/gauge_controller/examples/schema.rs
+++ b/contracts/gauge_controller/examples/schema.rs
@@ -4,7 +4,8 @@ use std::fs::create_dir_all;
 
 use anchor_token::gauge_controller::{
     AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
-    GaugeWeightResponse, InstantiateMsg, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
+    GaugeRelativeWeightResponse, GaugeWeightResponse, InstantiateMsg, QueryMsg,
+    TotalWeightResponse,
 };
 
 fn main() {
@@ -15,7 +16,7 @@ fn main() {
 
     export_schema(&schema_for!(GaugeWeightResponse), &out_dir);
     export_schema(&schema_for!(TotalWeightResponse), &out_dir);
-    export_schema(&schema_for!(RelativeWeightResponse), &out_dir);
+    export_schema(&schema_for!(GaugeRelativeWeightResponse), &out_dir);
     export_schema(&schema_for!(GaugeCountResponse), &out_dir);
     export_schema(&schema_for!(GaugeAddrResponse), &out_dir);
     export_schema(&schema_for!(AllGaugeAddrResponse), &out_dir);

--- a/contracts/gauge_controller/examples/schema.rs
+++ b/contracts/gauge_controller/examples/schema.rs
@@ -4,8 +4,8 @@ use std::fs::create_dir_all;
 
 use anchor_token::gauge_controller::{
     AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
-    GaugeRelativeWeightResponse, GaugeWeightResponse, InstantiateMsg, QueryMsg,
-    TotalWeightResponse,
+    GaugeRelativeWeightAtResponse, GaugeRelativeWeightResponse, GaugeWeightAtResponse,
+    GaugeWeightResponse, InstantiateMsg, QueryMsg, TotalWeightAtResponse, TotalWeightResponse,
 };
 
 fn main() {
@@ -15,8 +15,11 @@ fn main() {
     remove_schemas(&out_dir).unwrap();
 
     export_schema(&schema_for!(GaugeWeightResponse), &out_dir);
+    export_schema(&schema_for!(GaugeWeightAtResponse), &out_dir);
     export_schema(&schema_for!(TotalWeightResponse), &out_dir);
+    export_schema(&schema_for!(TotalWeightAtResponse), &out_dir);
     export_schema(&schema_for!(GaugeRelativeWeightResponse), &out_dir);
+    export_schema(&schema_for!(GaugeRelativeWeightAtResponse), &out_dir);
     export_schema(&schema_for!(GaugeCountResponse), &out_dir);
     export_schema(&schema_for!(GaugeAddrResponse), &out_dir);
     export_schema(&schema_for!(AllGaugeAddrResponse), &out_dir);

--- a/contracts/gauge_controller/rustfmt.toml
+++ b/contracts/gauge_controller/rustfmt.toml
@@ -1,0 +1,15 @@
+# stable
+newline_style = "unix"
+hard_tabs = false
+tab_spaces = 4
+
+# unstable... should we require `rustup run nightly cargo fmt` ?
+# or just update the style guide when they are stable?
+#fn_single_line = true
+#format_code_in_doc_comments = true
+#overflow_delimited_expr = true
+#reorder_impl_items = true
+#struct_field_align_threshold = 20
+#struct_lit_single_line = true
+#report_todo = "Always"
+

--- a/contracts/gauge_controller/schema/all_gauge_addr_response.json
+++ b/contracts/gauge_controller/schema/all_gauge_addr_response.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AllGaugeAddrResponse",
+  "type": "object",
+  "required": [
+    "all_gauge_addr"
+  ],
+  "properties": {
+    "all_gauge_addr": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/config_response.json
+++ b/contracts/gauge_controller/schema/config_response.json
@@ -3,20 +3,19 @@
   "title": "ConfigResponse",
   "type": "object",
   "required": [
-    "voting_escrow_contract"
+    "anchor_token",
+    "anchor_voting_escorw",
+    "owner"
   ],
   "properties": {
-    "voting_escrow_contract": {
-      "$ref": "#/definitions/CanonicalAddr"
-    }
-  },
-  "definitions": {
-    "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+    "anchor_token": {
       "type": "string"
     },
-    "CanonicalAddr": {
-      "$ref": "#/definitions/Binary"
+    "anchor_voting_escorw": {
+      "type": "string"
+    },
+    "owner": {
+      "type": "string"
     }
   }
 }

--- a/contracts/gauge_controller/schema/config_response.json
+++ b/contracts/gauge_controller/schema/config_response.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ConfigResponse",
+  "type": "object",
+  "required": [
+    "voting_escrow_contract"
+  ],
+  "properties": {
+    "voting_escrow_contract": {
+      "$ref": "#/definitions/CanonicalAddr"
+    }
+  },
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "CanonicalAddr": {
+      "$ref": "#/definitions/Binary"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/config_response.json
+++ b/contracts/gauge_controller/schema/config_response.json
@@ -4,14 +4,14 @@
   "type": "object",
   "required": [
     "anchor_token",
-    "anchor_voting_escorw",
+    "anchor_voting_escrow",
     "owner"
   ],
   "properties": {
     "anchor_token": {
       "type": "string"
     },
-    "anchor_voting_escorw": {
+    "anchor_voting_escrow": {
       "type": "string"
     },
     "owner": {

--- a/contracts/gauge_controller/schema/execute_msg.json
+++ b/contracts/gauge_controller/schema/execute_msg.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "add_gauge"
+      ],
+      "properties": {
+        "add_gauge": {
+          "type": "object",
+          "required": [
+            "addr",
+            "weight"
+          ],
+          "properties": {
+            "addr": {
+              "$ref": "#/definitions/CanonicalAddr"
+            },
+            "weight": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "change_gauge_weight"
+      ],
+      "properties": {
+        "change_gauge_weight": {
+          "type": "object",
+          "required": [
+            "addr",
+            "weight"
+          ],
+          "properties": {
+            "addr": {
+              "$ref": "#/definitions/CanonicalAddr"
+            },
+            "weight": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "vote_for_gauge_weight"
+      ],
+      "properties": {
+        "vote_for_gauge_weight": {
+          "type": "object",
+          "required": [
+            "addr",
+            "user_weight"
+          ],
+          "properties": {
+            "addr": {
+              "$ref": "#/definitions/CanonicalAddr"
+            },
+            "user_weight": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "CanonicalAddr": {
+      "$ref": "#/definitions/Binary"
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/execute_msg.json
+++ b/contracts/gauge_controller/schema/execute_msg.json
@@ -11,11 +11,11 @@
         "add_gauge": {
           "type": "object",
           "required": [
-            "addr",
+            "gauge_addr",
             "weight"
           ],
           "properties": {
-            "addr": {
+            "gauge_addr": {
               "type": "string"
             },
             "weight": {
@@ -35,11 +35,11 @@
         "change_gauge_weight": {
           "type": "object",
           "required": [
-            "addr",
+            "gauge_addr",
             "weight"
           ],
           "properties": {
-            "addr": {
+            "gauge_addr": {
               "type": "string"
             },
             "weight": {
@@ -59,11 +59,11 @@
         "vote_for_gauge_weight": {
           "type": "object",
           "required": [
-            "addr",
+            "gauge_addr",
             "ratio"
           ],
           "properties": {
-            "addr": {
+            "gauge_addr": {
               "type": "string"
             },
             "ratio": {

--- a/contracts/gauge_controller/schema/execute_msg.json
+++ b/contracts/gauge_controller/schema/execute_msg.json
@@ -75,38 +75,6 @@
         }
       },
       "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "required": [
-        "checkpoint_all"
-      ],
-      "properties": {
-        "checkpoint_all": {
-          "type": "object"
-        }
-      },
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "required": [
-        "checkpoint_gauge"
-      ],
-      "properties": {
-        "checkpoint_gauge": {
-          "type": "object",
-          "required": [
-            "addr"
-          ],
-          "properties": {
-            "addr": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/gauge_controller/schema/execute_msg.json
+++ b/contracts/gauge_controller/schema/execute_msg.json
@@ -16,7 +16,7 @@
           ],
           "properties": {
             "addr": {
-              "$ref": "#/definitions/CanonicalAddr"
+              "type": "string"
             },
             "weight": {
               "$ref": "#/definitions/Uint128"
@@ -40,7 +40,7 @@
           ],
           "properties": {
             "addr": {
-              "$ref": "#/definitions/CanonicalAddr"
+              "type": "string"
             },
             "weight": {
               "$ref": "#/definitions/Uint128"
@@ -64,7 +64,7 @@
           ],
           "properties": {
             "addr": {
-              "$ref": "#/definitions/CanonicalAddr"
+              "type": "string"
             },
             "user_weight": {
               "$ref": "#/definitions/Uint128"
@@ -76,13 +76,6 @@
     }
   ],
   "definitions": {
-    "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
-      "type": "string"
-    },
-    "CanonicalAddr": {
-      "$ref": "#/definitions/Binary"
-    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"

--- a/contracts/gauge_controller/schema/execute_msg.json
+++ b/contracts/gauge_controller/schema/execute_msg.json
@@ -60,14 +60,48 @@
           "type": "object",
           "required": [
             "addr",
-            "user_weight"
+            "voting_ratio"
           ],
           "properties": {
             "addr": {
               "type": "string"
             },
-            "user_weight": {
-              "$ref": "#/definitions/Uint128"
+            "voting_ratio": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "checkpoint_all"
+      ],
+      "properties": {
+        "checkpoint_all": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "checkpoint_gauge"
+      ],
+      "properties": {
+        "checkpoint_gauge": {
+          "type": "object",
+          "required": [
+            "addr"
+          ],
+          "properties": {
+            "addr": {
+              "type": "string"
             }
           }
         }

--- a/contracts/gauge_controller/schema/execute_msg.json
+++ b/contracts/gauge_controller/schema/execute_msg.json
@@ -60,13 +60,13 @@
           "type": "object",
           "required": [
             "addr",
-            "voting_ratio"
+            "ratio"
           ],
           "properties": {
             "addr": {
               "type": "string"
             },
-            "voting_ratio": {
+            "ratio": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0

--- a/contracts/gauge_controller/schema/gauge_addr_response.json
+++ b/contracts/gauge_controller/schema/gauge_addr_response.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GaugeAddrResponse",
+  "type": "object",
+  "required": [
+    "gauge_addr"
+  ],
+  "properties": {
+    "gauge_addr": {
+      "$ref": "#/definitions/CanonicalAddr"
+    }
+  },
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "CanonicalAddr": {
+      "$ref": "#/definitions/Binary"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/gauge_addr_response.json
+++ b/contracts/gauge_controller/schema/gauge_addr_response.json
@@ -7,16 +7,7 @@
   ],
   "properties": {
     "gauge_addr": {
-      "$ref": "#/definitions/CanonicalAddr"
-    }
-  },
-  "definitions": {
-    "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
-    },
-    "CanonicalAddr": {
-      "$ref": "#/definitions/Binary"
     }
   }
 }

--- a/contracts/gauge_controller/schema/gauge_count_response.json
+++ b/contracts/gauge_controller/schema/gauge_count_response.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "NGaugesResponse",
+  "title": "GaugeCountResponse",
   "type": "object",
   "required": [
-    "n_gauges"
+    "gauge_count"
   ],
   "properties": {
-    "n_gauges": {
+    "gauge_count": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0

--- a/contracts/gauge_controller/schema/gauge_relative_weight_at_response.json
+++ b/contracts/gauge_controller/schema/gauge_relative_weight_at_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GaugeRelativeWeightAtResponse",
+  "type": "object",
+  "required": [
+    "gauge_relative_weight_at"
+  ],
+  "properties": {
+    "gauge_relative_weight_at": {
+      "$ref": "#/definitions/Decimal"
+    }
+  },
+  "definitions": {
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/gauge_relative_weight_response.json
+++ b/contracts/gauge_controller/schema/gauge_relative_weight_response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "RelativeWeightResponse",
+  "title": "GaugeRelativeWeightResponse",
   "type": "object",
   "required": [
     "relative_weight"

--- a/contracts/gauge_controller/schema/gauge_relative_weight_response.json
+++ b/contracts/gauge_controller/schema/gauge_relative_weight_response.json
@@ -3,10 +3,10 @@
   "title": "GaugeRelativeWeightResponse",
   "type": "object",
   "required": [
-    "relative_weight"
+    "gauge_relative_weight"
   ],
   "properties": {
-    "relative_weight": {
+    "gauge_relative_weight": {
       "$ref": "#/definitions/Decimal"
     }
   },

--- a/contracts/gauge_controller/schema/gauge_weight_at_response.json
+++ b/contracts/gauge_controller/schema/gauge_weight_at_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GaugeWeightAtResponse",
+  "type": "object",
+  "required": [
+    "gauge_weight_at"
+  ],
+  "properties": {
+    "gauge_weight_at": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/gauge_weight_response.json
+++ b/contracts/gauge_controller/schema/gauge_weight_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GaugeWeightResponse",
+  "type": "object",
+  "required": [
+    "gauge_weight"
+  ],
+  "properties": {
+    "gauge_weight": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/instantiate_msg.json
+++ b/contracts/gauge_controller/schema/instantiate_msg.json
@@ -3,20 +3,19 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
-    "voting_escrow_contract"
+    "anchor_token",
+    "anchor_voting_escorw",
+    "owner"
   ],
   "properties": {
-    "voting_escrow_contract": {
-      "$ref": "#/definitions/CanonicalAddr"
-    }
-  },
-  "definitions": {
-    "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+    "anchor_token": {
       "type": "string"
     },
-    "CanonicalAddr": {
-      "$ref": "#/definitions/Binary"
+    "anchor_voting_escorw": {
+      "type": "string"
+    },
+    "owner": {
+      "type": "string"
     }
   }
 }

--- a/contracts/gauge_controller/schema/instantiate_msg.json
+++ b/contracts/gauge_controller/schema/instantiate_msg.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "voting_escrow_contract"
+  ],
+  "properties": {
+    "voting_escrow_contract": {
+      "$ref": "#/definitions/CanonicalAddr"
+    }
+  },
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "CanonicalAddr": {
+      "$ref": "#/definitions/Binary"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/instantiate_msg.json
+++ b/contracts/gauge_controller/schema/instantiate_msg.json
@@ -4,14 +4,14 @@
   "type": "object",
   "required": [
     "anchor_token",
-    "anchor_voting_escorw",
+    "anchor_voting_escrow",
     "owner"
   ],
   "properties": {
     "anchor_token": {
       "type": "string"
     },
-    "anchor_voting_escorw": {
+    "anchor_voting_escrow": {
       "type": "string"
     },
     "owner": {

--- a/contracts/gauge_controller/schema/n_gauges_response.json
+++ b/contracts/gauge_controller/schema/n_gauges_response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NGaugesResponse",
+  "type": "object",
+  "required": [
+    "n_gauges"
+  ],
+  "properties": {
+    "n_gauges": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -95,10 +95,10 @@
     {
       "type": "object",
       "required": [
-        "relative_weight"
+        "gauge_relative_weight"
       ],
       "properties": {
-        "relative_weight": {
+        "gauge_relative_weight": {
           "type": "object",
           "required": [
             "addr",

--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -5,10 +5,10 @@
     {
       "type": "object",
       "required": [
-        "get_n_gauges"
+        "gauge_count"
       ],
       "properties": {
-        "get_n_gauges": {
+        "gauge_count": {
           "type": "object"
         }
       },
@@ -17,17 +17,17 @@
     {
       "type": "object",
       "required": [
-        "get_gauge_weight"
+        "gauge_weight"
       ],
       "properties": {
-        "get_gauge_weight": {
+        "gauge_weight": {
           "type": "object",
           "required": [
             "addr"
           ],
           "properties": {
             "addr": {
-              "$ref": "#/definitions/CanonicalAddr"
+              "type": "string"
             }
           }
         }
@@ -37,10 +37,10 @@
     {
       "type": "object",
       "required": [
-        "get_total_weight"
+        "total_weight"
       ],
       "properties": {
-        "get_total_weight": {
+        "total_weight": {
           "type": "object"
         }
       },
@@ -49,10 +49,10 @@
     {
       "type": "object",
       "required": [
-        "get_gauge_addr"
+        "gauge_addr"
       ],
       "properties": {
-        "get_gauge_addr": {
+        "gauge_addr": {
           "type": "object",
           "required": [
             "gauge_id"
@@ -71,10 +71,10 @@
     {
       "type": "object",
       "required": [
-        "get_config"
+        "all_gauge_addr"
       ],
       "properties": {
-        "get_config": {
+        "all_gauge_addr": {
           "type": "object"
         }
       },
@@ -83,10 +83,22 @@
     {
       "type": "object",
       "required": [
-        "get_relative_weight"
+        "config"
       ],
       "properties": {
-        "get_relative_weight": {
+        "config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "relative_weight"
+      ],
+      "properties": {
+        "relative_weight": {
           "type": "object",
           "required": [
             "addr",
@@ -94,7 +106,7 @@
           ],
           "properties": {
             "addr": {
-              "$ref": "#/definitions/CanonicalAddr"
+              "type": "string"
             },
             "time": {
               "$ref": "#/definitions/Uint128"
@@ -106,13 +118,6 @@
     }
   ],
   "definitions": {
-    "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
-      "type": "string"
-    },
-    "CanonicalAddr": {
-      "$ref": "#/definitions/Binary"
-    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"

--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -37,11 +37,105 @@
     {
       "type": "object",
       "required": [
+        "gauge_weight_at"
+      ],
+      "properties": {
+        "gauge_weight_at": {
+          "type": "object",
+          "required": [
+            "addr",
+            "time"
+          ],
+          "properties": {
+            "addr": {
+              "type": "string"
+            },
+            "time": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
         "total_weight"
       ],
       "properties": {
         "total_weight": {
           "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "total_weight_at"
+      ],
+      "properties": {
+        "total_weight_at": {
+          "type": "object",
+          "required": [
+            "time"
+          ],
+          "properties": {
+            "time": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "gauge_relative_weight"
+      ],
+      "properties": {
+        "gauge_relative_weight": {
+          "type": "object",
+          "required": [
+            "addr"
+          ],
+          "properties": {
+            "addr": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "gauge_relative_weight_at"
+      ],
+      "properties": {
+        "gauge_relative_weight_at": {
+          "type": "object",
+          "required": [
+            "addr",
+            "time"
+          ],
+          "properties": {
+            "addr": {
+              "type": "string"
+            },
+            "time": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
         }
       },
       "additionalProperties": false
@@ -88,26 +182,6 @@
       "properties": {
         "config": {
           "type": "object"
-        }
-      },
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "required": [
-        "gauge_relative_weight"
-      ],
-      "properties": {
-        "gauge_relative_weight": {
-          "type": "object",
-          "required": [
-            "addr"
-          ],
-          "properties": {
-            "addr": {
-              "type": "string"
-            }
-          }
         }
       },
       "additionalProperties": false

--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -101,26 +101,16 @@
         "gauge_relative_weight": {
           "type": "object",
           "required": [
-            "addr",
-            "time"
+            "addr"
           ],
           "properties": {
             "addr": {
               "type": "string"
-            },
-            "time": {
-              "$ref": "#/definitions/Uint128"
             }
           }
         }
       },
       "additionalProperties": false
     }
-  ],
-  "definitions": {
-    "Uint128": {
-      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
-      "type": "string"
-    }
-  }
+  ]
 }

--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -5,6 +5,18 @@
     {
       "type": "object",
       "required": [
+        "get_n_gauges"
+      ],
+      "properties": {
+        "get_n_gauges": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
         "get_gauge_weight"
       ],
       "properties": {
@@ -29,6 +41,40 @@
       ],
       "properties": {
         "get_total_weight": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_gauge_addr"
+      ],
+      "properties": {
+        "get_gauge_addr": {
+          "type": "object",
+          "required": [
+            "gauge_id"
+          ],
+          "properties": {
+            "gauge_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_config"
+      ],
+      "properties": {
+        "get_config": {
           "type": "object"
         }
       },

--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "get_gauge_weight"
+      ],
+      "properties": {
+        "get_gauge_weight": {
+          "type": "object",
+          "required": [
+            "addr"
+          ],
+          "properties": {
+            "addr": {
+              "$ref": "#/definitions/CanonicalAddr"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_total_weight"
+      ],
+      "properties": {
+        "get_total_weight": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_relative_weight"
+      ],
+      "properties": {
+        "get_relative_weight": {
+          "type": "object",
+          "required": [
+            "addr",
+            "time"
+          ],
+          "properties": {
+            "addr": {
+              "$ref": "#/definitions/CanonicalAddr"
+            },
+            "time": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "CanonicalAddr": {
+      "$ref": "#/definitions/Binary"
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -23,10 +23,10 @@
         "gauge_weight": {
           "type": "object",
           "required": [
-            "addr"
+            "gauge_addr"
           ],
           "properties": {
-            "addr": {
+            "gauge_addr": {
               "type": "string"
             }
           }
@@ -43,11 +43,11 @@
         "gauge_weight_at": {
           "type": "object",
           "required": [
-            "addr",
+            "gauge_addr",
             "time"
           ],
           "properties": {
-            "addr": {
+            "gauge_addr": {
               "type": "string"
             },
             "time": {
@@ -103,10 +103,10 @@
         "gauge_relative_weight": {
           "type": "object",
           "required": [
-            "addr"
+            "gauge_addr"
           ],
           "properties": {
-            "addr": {
+            "gauge_addr": {
               "type": "string"
             }
           }
@@ -123,11 +123,11 @@
         "gauge_relative_weight_at": {
           "type": "object",
           "required": [
-            "addr",
+            "gauge_addr",
             "time"
           ],
           "properties": {
-            "addr": {
+            "gauge_addr": {
               "type": "string"
             },
             "time": {

--- a/contracts/gauge_controller/schema/relative_weight_response.json
+++ b/contracts/gauge_controller/schema/relative_weight_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RelativeWeightResponse",
+  "type": "object",
+  "required": [
+    "relative_weight"
+  ],
+  "properties": {
+    "relative_weight": {
+      "$ref": "#/definitions/Decimal"
+    }
+  },
+  "definitions": {
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/total_weight_at_response.json
+++ b/contracts/gauge_controller/schema/total_weight_at_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TotalWeightAtResponse",
+  "type": "object",
+  "required": [
+    "total_weight_at"
+  ],
+  "properties": {
+    "total_weight_at": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/schema/total_weight_response.json
+++ b/contracts/gauge_controller/schema/total_weight_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TotalWeightResponse",
+  "type": "object",
+  "required": [
+    "total_weight"
+  ],
+  "properties": {
+    "total_weight": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/gauge_controller/src/contract.rs
+++ b/contracts/gauge_controller/src/contract.rs
@@ -107,7 +107,6 @@ fn add_gauge(
     let gauge_count = GAUGE_COUNT.load(deps.storage)?;
 
     GAUGE_ADDR.save(deps.storage, U64Key::new(gauge_count), &addr)?;
-
     GAUGE_COUNT.save(deps.storage, &(gauge_count + 1))?;
 
     let period = get_period(env.block.time.seconds());
@@ -308,9 +307,11 @@ fn query_gauge_relative_weight(
     let addr = deps.api.addr_validate(&addr)?;
     let gauge_weight = get_gauge_weight_at(deps.storage, &addr, env.block.time.seconds())?;
     let total_weight = get_total_weight_at(deps.storage, env.block.time.seconds())?;
+
     if total_weight == Uint128::zero() {
         return Err(ContractError::TotalWeightIsZero {});
     }
+
     Ok(GaugeRelativeWeightResponse {
         gauge_relative_weight: Decimal::from_ratio(gauge_weight, total_weight),
     })
@@ -322,6 +323,7 @@ fn query_gauge_weight_at(
     time: u64,
 ) -> Result<GaugeWeightAtResponse, ContractError> {
     let addr = deps.api.addr_validate(&addr)?;
+
     Ok(GaugeWeightAtResponse {
         gauge_weight_at: get_gauge_weight_at(deps.storage, &addr, time)?,
     })
@@ -341,9 +343,11 @@ fn query_gauge_relative_weight_at(
     let addr = deps.api.addr_validate(&addr)?;
     let gauge_weight = get_gauge_weight_at(deps.storage, &addr, time)?;
     let total_weight = get_total_weight_at(deps.storage, time)?;
+
     if total_weight == Uint128::zero() {
         return Err(ContractError::TotalWeightIsZero {});
     }
+
     Ok(GaugeRelativeWeightAtResponse {
         gauge_relative_weight_at: Decimal::from_ratio(gauge_weight, total_weight),
     })

--- a/contracts/gauge_controller/src/contract.rs
+++ b/contracts/gauge_controller/src/contract.rs
@@ -17,7 +17,8 @@ use cw_storage_plus::U64Key;
 
 use anchor_token::gauge_controller::{
     AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
-    GaugeWeightResponse, InstantiateMsg, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
+    GaugeRelativeWeightResponse, GaugeWeightResponse, InstantiateMsg, QueryMsg,
+    TotalWeightResponse,
 };
 
 use std::cmp::max;
@@ -77,7 +78,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::AllGaugeAddr {} => Ok(to_binary(&query_all_gauge_addr(deps)?)?),
         QueryMsg::Config {} => Ok(to_binary(&query_config(deps)?)?),
         QueryMsg::GaugeRelativeWeight { addr } => {
-            Ok(to_binary(&query_relative_weight(deps, addr)?)?)
+            Ok(to_binary(&query_gauge_relative_weight(deps, addr)?)?)
         }
     }
 }
@@ -332,13 +333,13 @@ fn query_total_weight(deps: Deps) -> Result<TotalWeightResponse, ContractError> 
     })
 }
 
-fn query_relative_weight(
+fn query_gauge_relative_weight(
     deps: Deps,
     addr: String,
-) -> Result<RelativeWeightResponse, ContractError> {
+) -> Result<GaugeRelativeWeightResponse, ContractError> {
     let gauge_weight = query_gauge_weight(deps, addr)?.gauge_weight;
     let total_weight = query_total_weight(deps)?.total_weight;
-    Ok(RelativeWeightResponse {
+    Ok(GaugeRelativeWeightResponse {
         relative_weight: Decimal::from_ratio(gauge_weight, total_weight),
     })
 }

--- a/contracts/gauge_controller/src/contract.rs
+++ b/contracts/gauge_controller/src/contract.rs
@@ -2,14 +2,12 @@ use crate::error::ContractError;
 use crate::state::{
     config_read, config_store, gauge_addr_read, gauge_addr_store, gauge_count_read,
     gauge_count_store, gauge_info_read, gauge_info_store, gauge_weight_read, gauge_weight_store,
-    Config, GaugeInfo, UserVote, Weight,
+    Config, GaugeInfo, Weight,
 };
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{
-    to_binary, Binary, CanonicalAddr, Deps, DepsMut, Env, MessageInfo, Response, Uint128,
-};
+use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
 
 use anchor_token::gauge_controller::{
     AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,

--- a/contracts/gauge_controller/src/contract.rs
+++ b/contracts/gauge_controller/src/contract.rs
@@ -146,9 +146,7 @@ fn change_gauge_weight(
     let latest_checkpoint = fetch_latest_checkpoint(deps.storage, &addr)?;
 
     let pair = latest_checkpoint.unwrap();
-    let (latest_period, latest_weight) = deserialize_pair::<GaugeWeight>(Ok(pair))?;
-
-    assert_eq!(latest_period, period);
+    let (_, latest_weight) = deserialize_pair::<GaugeWeight>(Ok(pair))?;
 
     GAUGE_WEIGHT.save(
         deps.storage,

--- a/contracts/gauge_controller/src/contract.rs
+++ b/contracts/gauge_controller/src/contract.rs
@@ -368,9 +368,7 @@ fn query_all_gauge_addr(deps: Deps) -> Result<AllGaugeAddrResponse, ContractErro
         all_gauge_addr.push(gauge_addr.to_string());
     }
 
-    Ok(AllGaugeAddrResponse {
-        all_gauge_addr,
-    })
+    Ok(AllGaugeAddrResponse { all_gauge_addr })
 }
 
 fn query_config(deps: Deps) -> Result<ConfigResponse, ContractError> {

--- a/contracts/gauge_controller/src/contract.rs
+++ b/contracts/gauge_controller/src/contract.rs
@@ -1,0 +1,177 @@
+use crate::error::ContractError;
+use crate::state::{
+    config_read, config_store, gauge_addr_read, gauge_addr_store, gauge_info_read,
+    gauge_info_store, gauge_weight_read, gauge_weight_store, n_gauges_read, n_gauges_store, Config,
+    GaugeInfo, UserVote, Weight,
+};
+
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, Binary, CanonicalAddr, Deps, DepsMut, Env, MessageInfo, Response, Uint128,
+};
+
+use anchor_token::gauge_controller::{
+    ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeWeightResponse, InstantiateMsg,
+    NGaugesResponse, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
+};
+
+const WEEK: u64 = 7 * 24 * 60 * 60;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let config = Config {
+        voting_escrow_contract: msg.voting_escrow_contract,
+    };
+    config_store(deps.storage).save(&config)?;
+    n_gauges_store(deps.storage).save(&0)?;
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::AddGauge { addr, weight } => add_gauge(deps, env, info, addr, weight),
+        ExecuteMsg::ChangeGaugeWeight { addr, weight } => {
+            change_gauge_weight(deps, env, info, addr, weight)
+        }
+        ExecuteMsg::VoteForGaugeWeight { addr, user_weight } => {
+            vote_for_gauge_weight(deps, env, info, addr, user_weight)
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+    match msg {
+        QueryMsg::GetNGauges {} => Ok(to_binary(&get_n_gauges(deps)?)?),
+        QueryMsg::GetGaugeWeight { addr } => Ok(to_binary(&get_gauge_weight(deps, addr)?)?),
+        QueryMsg::GetTotalWeight {} => Ok(to_binary(&get_total_weight(deps)?)?),
+        QueryMsg::GetGaugeAddr { gauge_id } => Ok(to_binary(&get_gauge_addr(deps, gauge_id)?)?),
+        QueryMsg::GetConfig {} => Ok(to_binary(&get_config(deps)?)?),
+        QueryMsg::GetRelativeWeight { addr, time } => {
+            Ok(to_binary(&get_relative_weight(deps, addr, time)?)?)
+        }
+    }
+}
+
+fn _get_period(time: u64) -> u64 {
+    (time / WEEK + WEEK) * WEEK
+}
+
+fn add_gauge(
+    deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    addr: CanonicalAddr,
+    weight: Uint128,
+) -> Result<Response, ContractError> {
+    let mut n_gauges = n_gauges_read(deps.storage).load()?;
+    gauge_addr_store(deps.storage).save(&n_gauges.to_string().as_bytes(), &addr)?;
+    n_gauges += 1;
+    n_gauges_store(deps.storage).save(&n_gauges)?;
+    let period = _get_period(env.block.time.seconds());
+    gauge_weight_store(deps.storage, &addr).save(
+        &period.to_string().as_bytes(),
+        &Weight {
+            bias: weight,
+            slope: Uint128::zero(),
+            slope_change: Uint128::zero(),
+        },
+    )?;
+    gauge_info_store(deps.storage).save(
+        &addr,
+        &GaugeInfo {
+            last_vote_period: period,
+        },
+    )?;
+    Ok(Response::default())
+}
+
+fn change_gauge_weight(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _addr: CanonicalAddr,
+    _weight: Uint128,
+) -> Result<Response, ContractError> {
+    Err(ContractError::NotImplement {})
+}
+
+fn vote_for_gauge_weight(
+    deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    addr: CanonicalAddr,
+    user_weight: Uint128,
+) -> Result<Response, ContractError> {
+    let period = _get_period(env.block.time.seconds());
+    gauge_weight_store(deps.storage, &addr).save(
+        &period.to_string().as_bytes(),
+        &Weight {
+            bias: user_weight,
+            slope: Uint128::from(234_u64),
+            slope_change: Uint128::from(345_u64),
+        },
+    )?;
+    gauge_info_store(deps.storage).save(
+        &addr,
+        &GaugeInfo {
+            last_vote_period: period,
+        },
+    )?;
+    Ok(Response::default())
+}
+
+fn get_gauge_weight(deps: Deps, addr: CanonicalAddr) -> Result<GaugeWeightResponse, ContractError> {
+    let period = gauge_info_read(deps.storage).load(&addr)?.last_vote_period;
+    Ok(GaugeWeightResponse {
+        gauge_weight: gauge_weight_read(deps.storage, &addr)
+            .load(&period.to_string().as_bytes())?
+            .bias,
+    })
+}
+
+fn get_total_weight(_deps: Deps) -> Result<TotalWeightResponse, ContractError> {
+    Err(ContractError::NotImplement {})
+}
+
+fn get_relative_weight(
+    _deps: Deps,
+    _addr: CanonicalAddr,
+    _time: Uint128,
+) -> Result<RelativeWeightResponse, ContractError> {
+    Err(ContractError::NotImplement {})
+}
+
+fn get_n_gauges(deps: Deps) -> Result<NGaugesResponse, ContractError> {
+    Ok(NGaugesResponse {
+        n_gauges: n_gauges_read(deps.storage).load()?,
+    })
+}
+
+fn get_gauge_addr(deps: Deps, gauge_id: u64) -> Result<GaugeAddrResponse, ContractError> {
+    if gauge_id >= n_gauges_read(deps.storage).load()? {
+        return Err(ContractError::GaugeNotFound {});
+    }
+    Ok(GaugeAddrResponse {
+        gauge_addr: gauge_addr_read(deps.storage).load(&gauge_id.to_string().as_bytes())?,
+    })
+}
+
+fn get_config(deps: Deps) -> Result<ConfigResponse, ContractError> {
+    let config = config_read(deps.storage).load()?;
+    Ok(ConfigResponse {
+        voting_escrow_contract: config.voting_escrow_contract,
+    })
+}

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -18,12 +18,21 @@ pub enum ContractError {
     #[error("Gauge Not Found")]
     GaugeNotFound {},
 
-    #[error("Gauge Already Exist")]
-    GaugeAlreadyExist {},
+    #[error("Gauge Already Exists")]
+    GaugeAlreadyExists {},
 
     #[error("Deserialization Error")]
     DeserializationError {},
 
     #[error("Timestamp Error")]
     TimestampError {},
+
+    #[error("Invalid Voting Weight")]
+    InvalidVotingWeight {},
+
+    #[error("Lock Expires Too Soon")]
+    LockExpiresTooSoon {},
+
+    #[error("Vote Too Often")]
+    VoteTooOften {},
 }

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -20,4 +20,10 @@ pub enum ContractError {
 
     #[error("Gauge Already Exist")]
     GaugeAlreadyExist {},
+
+    #[error("Deserialization Error")]
+    DeserializationError {},
+
+    #[error("Timestamp Error")]
+    TimestampError {},
 }

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -12,9 +12,6 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("Not Implement")]
-    NotImplement {},
-
     #[error("Gauge Not Found")]
     GaugeNotFound {},
 

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -32,4 +32,10 @@ pub enum ContractError {
 
     #[error("Vote Too Often")]
     VoteTooOften {},
+
+    #[error("Total Weight Is Zero")]
+    TotalWeightIsZero {},
+
+    #[error("Insufficient Voting Ratio")]
+    InsufficientVotingRatio {},
 }

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -18,9 +18,6 @@ pub enum ContractError {
     #[error("Gauge Already Exists")]
     GaugeAlreadyExists {},
 
-    #[error("Deserialization Error")]
-    DeserializationError {},
-
     #[error("Timestamp Error")]
     TimestampError {},
 

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -17,4 +17,7 @@ pub enum ContractError {
 
     #[error("Gauge Not Found")]
     GaugeNotFound {},
+
+    #[error("Gauge Already Exist")]
+    GaugeAlreadyExist {},
 }

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -24,8 +24,8 @@ pub enum ContractError {
     #[error("Timestamp Error")]
     TimestampError {},
 
-    #[error("Invalid Voting Weight")]
-    InvalidVotingWeight {},
+    #[error("Invalid Voting Ratio")]
+    InvalidVotingRatio {},
 
     #[error("Lock Expires Too Soon")]
     LockExpiresTooSoon {},

--- a/contracts/gauge_controller/src/error.rs
+++ b/contracts/gauge_controller/src/error.rs
@@ -1,0 +1,20 @@
+use cosmwasm_std::{OverflowError, StdError};
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    OverflowError(#[from] OverflowError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Not Implement")]
+    NotImplement {},
+
+    #[error("Gauge Not Found")]
+    GaugeNotFound {},
+}

--- a/contracts/gauge_controller/src/lib.rs
+++ b/contracts/gauge_controller/src/lib.rs
@@ -2,6 +2,7 @@ pub mod contract;
 
 mod error;
 mod state;
+mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/contracts/gauge_controller/src/lib.rs
+++ b/contracts/gauge_controller/src/lib.rs
@@ -2,3 +2,6 @@ pub mod contract;
 
 mod error;
 mod state;
+
+#[cfg(test)]
+mod tests;

--- a/contracts/gauge_controller/src/lib.rs
+++ b/contracts/gauge_controller/src/lib.rs
@@ -5,3 +5,6 @@ mod state;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod mock_querier;

--- a/contracts/gauge_controller/src/lib.rs
+++ b/contracts/gauge_controller/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod contract;
+
+mod error;
+mod state;

--- a/contracts/gauge_controller/src/mock_querier.rs
+++ b/contracts/gauge_controller/src/mock_querier.rs
@@ -48,21 +48,29 @@ impl WasmMockQuerier {
                 contract_addr: _,
                 msg,
             }) => match from_binary(msg).unwrap() {
-                VotingEscrowContractQueryMsg::LastUserSlope { user: _ } => {
+                VotingEscrowContractQueryMsg::LastUserSlope { user } => {
+                    let slope = if user == String::from("user_1") {
+                        Decimal::from_ratio(Uint128::from(998244353_u64), Uint128::from(100_u64))
+                    } else if user == String::from("user_2") {
+                        Decimal::from_ratio(Uint128::from(1000000007_u64), Uint128::from(66_u64))
+                    } else {
+                        panic!("INVALID USER");
+                    };
                     SystemResult::Ok(ContractResult::Ok(
-                        to_binary(&UserSlopResponse {
-                            slope: Decimal::from_ratio(
-                                Uint128::from(998244353_u64),
-                                Uint128::from(100_u64),
-                            ),
-                        })
-                        .unwrap(),
+                        to_binary(&UserSlopResponse { slope: slope }).unwrap(),
                     ))
                 }
-                VotingEscrowContractQueryMsg::UserUnlockPeriod { user: _ } => {
+                VotingEscrowContractQueryMsg::UserUnlockPeriod { user } => {
+                    let time = if user == String::from("user_1") {
+                        BASE_TIME + WEEK * 100
+                    } else if user == String::from("user_2") {
+                        BASE_TIME + WEEK * 66
+                    } else {
+                        panic!("INVALID USER");
+                    };
                     SystemResult::Ok(ContractResult::Ok(
                         to_binary(&UserUnlockPeriodResponse {
-                            unlock_period: get_period(BASE_TIME + WEEK * 100),
+                            unlock_period: get_period(time),
                         })
                         .unwrap(),
                     ))

--- a/contracts/gauge_controller/src/mock_querier.rs
+++ b/contracts/gauge_controller/src/mock_querier.rs
@@ -1,9 +1,13 @@
 use crate::state::{UserSlopResponse, UserUnlockPeriodResponse, VotingEscrowContractQueryMsg};
+use crate::utils::{get_period, WEEK};
+
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Coin, ContractResult, Decimal, Empty, OwnedDeps, Querier,
-    QuerierResult, QueryRequest, SystemError, SystemResult, WasmQuery,
+    QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
+
+pub(crate) const BASE_TIME: u64 = WEEK * 1000 + 10;
 
 pub fn mock_dependencies(
     contract_balance: &[Coin],
@@ -47,14 +51,20 @@ impl WasmMockQuerier {
                 VotingEscrowContractQueryMsg::LastUserSlope { user: _ } => {
                     SystemResult::Ok(ContractResult::Ok(
                         to_binary(&UserSlopResponse {
-                            slope: Decimal::from_ratio(2_u64, 3_u64),
+                            slope: Decimal::from_ratio(
+                                Uint128::from(998244353_u64),
+                                Uint128::from(100_u64),
+                            ),
                         })
                         .unwrap(),
                     ))
                 }
                 VotingEscrowContractQueryMsg::UserUnlockPeriod { user: _ } => {
                     SystemResult::Ok(ContractResult::Ok(
-                        to_binary(&UserUnlockPeriodResponse { unlock_period: 666 }).unwrap(),
+                        to_binary(&UserUnlockPeriodResponse {
+                            unlock_period: get_period(BASE_TIME + WEEK * 100),
+                        })
+                        .unwrap(),
                     ))
                 }
             },

--- a/contracts/gauge_controller/src/mock_querier.rs
+++ b/contracts/gauge_controller/src/mock_querier.rs
@@ -49,25 +49,25 @@ impl WasmMockQuerier {
                 msg,
             }) => match from_binary(msg).unwrap() {
                 VotingEscrowContractQueryMsg::LastUserSlope { user } => {
-                    let slope = if user == String::from("user_1") {
+                    let slope = if user == *"user_1" {
                         Decimal::from_ratio(Uint128::from(998244353_u64), Uint128::from(100_u64))
-                    } else if user == String::from("user_2") {
+                    } else if user == *"user_2" {
                         Decimal::from_ratio(Uint128::from(1000000007_u64), Uint128::from(66_u64))
-                    } else if user == String::from("user_3") {
+                    } else if user == *"user_3" {
                         Decimal::from_ratio(Uint128::from(847426363_u64), Uint128::from(100_u64))
                     } else {
                         panic!("INVALID USER");
                     };
                     SystemResult::Ok(ContractResult::Ok(
-                        to_binary(&UserSlopResponse { slope: slope }).unwrap(),
+                        to_binary(&UserSlopResponse { slope }).unwrap(),
                     ))
                 }
                 VotingEscrowContractQueryMsg::UserUnlockPeriod { user } => {
-                    let time = if user == String::from("user_1") {
+                    let time = if user == *"user_1" {
                         BASE_TIME + WEEK * 100
-                    } else if user == String::from("user_2") {
+                    } else if user == *"user_2" {
                         BASE_TIME + WEEK * 66
-                    } else if user == String::from("user_3") {
+                    } else if user == *"user_3" {
                         BASE_TIME + WEEK * 100
                     } else {
                         panic!("INVALID USER");
@@ -87,6 +87,6 @@ impl WasmMockQuerier {
 
 impl WasmMockQuerier {
     pub fn new(base: MockQuerier<Empty>) -> Self {
-        WasmMockQuerier { base: base }
+        WasmMockQuerier { base }
     }
 }

--- a/contracts/gauge_controller/src/mock_querier.rs
+++ b/contracts/gauge_controller/src/mock_querier.rs
@@ -1,8 +1,8 @@
 use crate::state::{UserSlopResponse, UserUnlockPeriodResponse, VotingEscrowContractQueryMsg};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, from_slice, to_binary, Coin, ContractResult, Empty, OwnedDeps, Querier,
-    QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+    from_binary, from_slice, to_binary, Coin, ContractResult, Decimal, Empty, OwnedDeps, Querier,
+    QuerierResult, QueryRequest, SystemError, SystemResult, WasmQuery,
 };
 
 pub fn mock_dependencies(
@@ -47,7 +47,7 @@ impl WasmMockQuerier {
                 VotingEscrowContractQueryMsg::LastUserSlope { user: _ } => {
                     SystemResult::Ok(ContractResult::Ok(
                         to_binary(&UserSlopResponse {
-                            slope: Uint128::from(233_u64),
+                            slope: Decimal::from_ratio(2_u64, 3_u64),
                         })
                         .unwrap(),
                     ))

--- a/contracts/gauge_controller/src/mock_querier.rs
+++ b/contracts/gauge_controller/src/mock_querier.rs
@@ -53,6 +53,8 @@ impl WasmMockQuerier {
                         Decimal::from_ratio(Uint128::from(998244353_u64), Uint128::from(100_u64))
                     } else if user == String::from("user_2") {
                         Decimal::from_ratio(Uint128::from(1000000007_u64), Uint128::from(66_u64))
+                    } else if user == String::from("user_3") {
+                        Decimal::from_ratio(Uint128::from(847426363_u64), Uint128::from(100_u64))
                     } else {
                         panic!("INVALID USER");
                     };
@@ -65,6 +67,8 @@ impl WasmMockQuerier {
                         BASE_TIME + WEEK * 100
                     } else if user == String::from("user_2") {
                         BASE_TIME + WEEK * 66
+                    } else if user == String::from("user_3") {
+                        BASE_TIME + WEEK * 100
                     } else {
                         panic!("INVALID USER");
                     };

--- a/contracts/gauge_controller/src/mock_querier.rs
+++ b/contracts/gauge_controller/src/mock_querier.rs
@@ -1,0 +1,70 @@
+use crate::state::{UserSlopResponse, UserUnlockPeriodResponse, VotingEscrowContractQueryMsg};
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{
+    from_binary, from_slice, to_binary, Coin, ContractResult, Empty, OwnedDeps, Querier,
+    QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+};
+
+pub fn mock_dependencies(
+    contract_balance: &[Coin],
+) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+    let custom_querier: WasmMockQuerier =
+        WasmMockQuerier::new(MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]));
+
+    OwnedDeps {
+        api: MockApi::default(),
+        storage: MockStorage::default(),
+        querier: custom_querier,
+    }
+}
+
+pub struct WasmMockQuerier {
+    base: MockQuerier<Empty>,
+}
+
+impl Querier for WasmMockQuerier {
+    fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+        let request: QueryRequest<Empty> = match from_slice(bin_request) {
+            Ok(v) => v,
+            Err(e) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: format!("Parsing query request: {}", e),
+                    request: bin_request.into(),
+                })
+            }
+        };
+        self.handle_query(&request)
+    }
+}
+
+impl WasmMockQuerier {
+    pub fn handle_query(&self, request: &QueryRequest<Empty>) -> QuerierResult {
+        match &request {
+            QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: _,
+                msg,
+            }) => match from_binary(msg).unwrap() {
+                VotingEscrowContractQueryMsg::LastUserSlope { user: _ } => {
+                    SystemResult::Ok(ContractResult::Ok(
+                        to_binary(&UserSlopResponse {
+                            slope: Uint128::from(233_u64),
+                        })
+                        .unwrap(),
+                    ))
+                }
+                VotingEscrowContractQueryMsg::UserUnlockPeriod { user: _ } => {
+                    SystemResult::Ok(ContractResult::Ok(
+                        to_binary(&UserUnlockPeriodResponse { unlock_period: 666 }).unwrap(),
+                    ))
+                }
+            },
+            _ => self.base.handle_query(request),
+        }
+    }
+}
+
+impl WasmMockQuerier {
+    pub fn new(base: MockQuerier<Empty>) -> Self {
+        WasmMockQuerier { base: base }
+    }
+}

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -39,6 +39,7 @@ pub struct UserVote {
     pub slope: Decimal,
     pub vote_period: u64,
     pub unlock_period: u64,
+    pub ratio: u64,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
@@ -52,3 +53,5 @@ pub const SLOPE_CHANGES: Map<(Addr, U64Key), Decimal> = Map::new("slope_changes"
 pub const GAUGE_ADDR: Map<U64Key, Addr> = Map::new("gauge_addr");
 
 pub const USER_VOTES: Map<(Addr, Addr), UserVote> = Map::new("user_votes");
+
+pub const USER_RATIO: Map<Addr, u64> = Map::new("user_used_ratio");

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -32,12 +32,6 @@ pub struct Config {
 pub struct GaugeWeight {
     pub bias: Uint128,
     pub slope: Uint128,
-    pub slope_change: Uint128,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct GaugeInfo {
-    pub last_vote_period: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -53,7 +47,7 @@ pub const GAUGE_COUNT: Item<u64> = Item::new("gauge_count");
 
 pub const GAUGE_WEIGHT: Map<(Addr, U64Key), GaugeWeight> = Map::new("gauge_weight");
 
-pub const GAUGE_INFO: Map<Addr, GaugeInfo> = Map::new("gauge_info");
+pub const SLOPE_CHANGES: Map<(Addr, U64Key), Uint128> = Map::new("slope_changes");
 
 pub const GAUGE_ADDR: Map<U64Key, Addr> = Map::new("gauge_addr");
 

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -7,6 +7,23 @@ use cosmwasm_storage::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VotingEscrowContractQueryMsg {
+    LastUserSlope { user: String },
+    UserUnlockPeriod { user: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
+pub struct UserSlopResponse {
+    pub slope: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
+pub struct UserUnlockPeriodResponse {
+    pub unlock_period: u64,
+}
+
 static KEY_CONFIG: &[u8] = b"config";
 static KEY_GAUGE_COUNT: &[u8] = b"gauge_count";
 

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -1,8 +1,5 @@
-use cosmwasm_std::{CanonicalAddr, Storage, Uint128};
-
-use cosmwasm_storage::{
-    singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton, Singleton,
-};
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map, U64Key};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -24,23 +21,15 @@ pub struct UserUnlockPeriodResponse {
     pub unlock_period: u64,
 }
 
-static KEY_CONFIG: &[u8] = b"config";
-static KEY_GAUGE_COUNT: &[u8] = b"gauge_count";
-
-static PREFIX_GAUGE_ADDR: &[u8] = b"gauge_addr";
-static PREFIX_GAUGE_INFO: &[u8] = b"gauge_info";
-static PREFIX_USER_VOTES: &[u8] = b"user_votes";
-static PREFIX_GAGUE_WEIGHT: &[u8] = b"gauge_weight";
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
-    pub owner: CanonicalAddr,
-    pub anchor_token: CanonicalAddr,
-    pub anchor_voting_escorw: CanonicalAddr,
+    pub owner: Addr,
+    pub anchor_token: Addr,
+    pub anchor_voting_escorw: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Weight {
+pub struct GaugeWeight {
     pub bias: Uint128,
     pub slope: Uint128,
     pub slope_change: Uint128,
@@ -58,48 +47,14 @@ pub struct UserVote {
     pub end_period: u64,
 }
 
-pub fn config_store(storage: &mut dyn Storage) -> Singleton<Config> {
-    singleton(storage, KEY_CONFIG)
-}
+pub const CONFIG: Item<Config> = Item::new("config");
 
-pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<Config> {
-    singleton_read(storage, KEY_CONFIG)
-}
+pub const GAUGE_COUNT: Item<u64> = Item::new("gauge_count");
 
-pub fn gauge_count_store(storage: &mut dyn Storage) -> Singleton<u64> {
-    singleton(storage, KEY_GAUGE_COUNT)
-}
+pub const GAUGE_WEIGHT: Map<(Addr, U64Key), GaugeWeight> = Map::new("gauge_weight");
 
-pub fn gauge_count_read(storage: &dyn Storage) -> ReadonlySingleton<u64> {
-    singleton_read(storage, KEY_GAUGE_COUNT)
-}
+pub const GAUGE_INFO: Map<Addr, GaugeInfo> = Map::new("gauge_info");
 
-pub fn gauge_weight_store<'a>(
-    storage: &'a mut dyn Storage,
-    gauge_addr: &'a CanonicalAddr,
-) -> Bucket<'a, Weight> {
-    Bucket::multilevel(storage, &[PREFIX_GAGUE_WEIGHT, &gauge_addr])
-}
+pub const GAUGE_ADDR: Map<U64Key, Addr> = Map::new("gauge_addr");
 
-pub fn gauge_weight_read<'a>(
-    storage: &'a dyn Storage,
-    gauge_addr: &'a CanonicalAddr,
-) -> ReadonlyBucket<'a, Weight> {
-    ReadonlyBucket::multilevel(storage, &[PREFIX_GAGUE_WEIGHT, &gauge_addr])
-}
-
-pub fn gauge_info_store(storage: &mut dyn Storage) -> Bucket<GaugeInfo> {
-    Bucket::multilevel(storage, &[PREFIX_GAUGE_INFO])
-}
-
-pub fn gauge_info_read(storage: &dyn Storage) -> ReadonlyBucket<GaugeInfo> {
-    ReadonlyBucket::multilevel(storage, &[PREFIX_GAUGE_INFO])
-}
-
-pub fn gauge_addr_store(storage: &mut dyn Storage) -> Bucket<CanonicalAddr> {
-    Bucket::multilevel(storage, &[PREFIX_GAUGE_ADDR])
-}
-
-pub fn gauge_addr_read(storage: &dyn Storage) -> ReadonlyBucket<CanonicalAddr> {
-    ReadonlyBucket::multilevel(storage, &[PREFIX_GAUGE_ADDR])
-}
+pub const USER_VOTES: Map<(Addr, Addr), UserVote> = Map::new("user_votes");

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 static KEY_CONFIG: &[u8] = b"config";
-static KEY_N_GAUGES: &[u8] = b"n_gauges";
+static KEY_GAUGE_COUNT: &[u8] = b"gauge_count";
 
 static PREFIX_GAUGE_ADDR: &[u8] = b"gauge_addr";
 static PREFIX_GAUGE_INFO: &[u8] = b"gauge_info";
@@ -17,7 +17,9 @@ static PREFIX_GAGUE_WEIGHT: &[u8] = b"gauge_weight";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
-    pub voting_escrow_contract: CanonicalAddr,
+    pub owner: CanonicalAddr,
+    pub anchor_token: CanonicalAddr,
+    pub anchor_voting_escorw: CanonicalAddr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -47,12 +49,12 @@ pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<Config> {
     singleton_read(storage, KEY_CONFIG)
 }
 
-pub fn n_gauges_store(storage: &mut dyn Storage) -> Singleton<u64> {
-    singleton(storage, KEY_N_GAUGES)
+pub fn gauge_count_store(storage: &mut dyn Storage) -> Singleton<u64> {
+    singleton(storage, KEY_GAUGE_COUNT)
 }
 
-pub fn n_gauges_read(storage: &dyn Storage) -> ReadonlySingleton<u64> {
-    singleton_read(storage, KEY_N_GAUGES)
+pub fn gauge_count_read(storage: &dyn Storage) -> ReadonlySingleton<u64> {
+    singleton_read(storage, KEY_GAUGE_COUNT)
 }
 
 pub fn gauge_weight_store<'a>(

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -36,9 +36,9 @@ pub struct GaugeWeight {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct UserVote {
-    pub slope: Uint128,
-    pub start_period: u64,
-    pub end_period: u64,
+    pub slope: Decimal,
+    pub vote_period: u64,
+    pub unlock_period: u64,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::{Addr, Decimal, Uint128};
 use cw_storage_plus::{Item, Map, U64Key};
 
 use schemars::JsonSchema;
@@ -13,7 +13,7 @@ pub enum VotingEscrowContractQueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
 pub struct UserSlopResponse {
-    pub slope: Uint128,
+    pub slope: Decimal,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
@@ -31,7 +31,7 @@ pub struct Config {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GaugeWeight {
     pub bias: Uint128,
-    pub slope: Uint128,
+    pub slope: Decimal,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -47,7 +47,7 @@ pub const GAUGE_COUNT: Item<u64> = Item::new("gauge_count");
 
 pub const GAUGE_WEIGHT: Map<(Addr, U64Key), GaugeWeight> = Map::new("gauge_weight");
 
-pub const SLOPE_CHANGES: Map<(Addr, U64Key), Uint128> = Map::new("slope_changes");
+pub const SLOPE_CHANGES: Map<(Addr, U64Key), Decimal> = Map::new("slope_changes");
 
 pub const GAUGE_ADDR: Map<U64Key, Addr> = Map::new("gauge_addr");
 

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -1,0 +1,86 @@
+use cosmwasm_std::{CanonicalAddr, Storage, Uint128};
+
+use cosmwasm_storage::{
+    singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton, Singleton,
+};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+static KEY_CONFIG: &[u8] = b"config";
+static KEY_N_GAUGES: &[u8] = b"n_gauges";
+
+static PREFIX_GAUGE_ADDR: &[u8] = b"gauge_addr";
+static PREFIX_GAUGE_INFO: &[u8] = b"gauge_info";
+static PREFIX_USER_VOTES: &[u8] = b"user_votes";
+static PREFIX_GAGUE_WEIGHT: &[u8] = b"gauge_weight";
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Config {
+    pub voting_escrow_contract: CanonicalAddr,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Weight {
+    pub bias: Uint128,
+    pub slope: Uint128,
+    pub slope_change: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct GaugeInfo {
+    pub last_vote_period: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct UserVote {
+    pub slope: Uint128,
+    pub start_period: u64,
+    pub end_period: u64,
+}
+
+pub fn config_store(storage: &mut dyn Storage) -> Singleton<Config> {
+    singleton(storage, KEY_CONFIG)
+}
+
+pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<Config> {
+    singleton_read(storage, KEY_CONFIG)
+}
+
+pub fn n_gauges_store(storage: &mut dyn Storage) -> Singleton<u64> {
+    singleton(storage, KEY_N_GAUGES)
+}
+
+pub fn n_gauges_read(storage: &dyn Storage) -> ReadonlySingleton<u64> {
+    singleton_read(storage, KEY_N_GAUGES)
+}
+
+pub fn gauge_weight_store<'a>(
+    storage: &'a mut dyn Storage,
+    gauge_addr: &'a CanonicalAddr,
+) -> Bucket<'a, Weight> {
+    Bucket::multilevel(storage, &[PREFIX_GAGUE_WEIGHT, &gauge_addr])
+}
+
+pub fn gauge_weight_read<'a>(
+    storage: &'a dyn Storage,
+    gauge_addr: &'a CanonicalAddr,
+) -> ReadonlyBucket<'a, Weight> {
+    ReadonlyBucket::multilevel(storage, &[PREFIX_GAGUE_WEIGHT, &gauge_addr])
+}
+
+pub fn gauge_info_store(storage: &mut dyn Storage) -> Bucket<GaugeInfo> {
+    Bucket::multilevel(storage, &[PREFIX_GAUGE_INFO])
+}
+
+pub fn gauge_info_read(storage: &dyn Storage) -> ReadonlyBucket<GaugeInfo> {
+    ReadonlyBucket::multilevel(storage, &[PREFIX_GAUGE_INFO])
+}
+
+pub fn gauge_addr_store(storage: &mut dyn Storage) -> Bucket<CanonicalAddr> {
+    Bucket::multilevel(storage, &[PREFIX_GAUGE_ADDR])
+}
+
+pub fn gauge_addr_read(storage: &dyn Storage) -> ReadonlyBucket<CanonicalAddr> {
+    ReadonlyBucket::multilevel(storage, &[PREFIX_GAUGE_ADDR])
+}

--- a/contracts/gauge_controller/src/state.rs
+++ b/contracts/gauge_controller/src/state.rs
@@ -25,7 +25,7 @@ pub struct UserUnlockPeriodResponse {
 pub struct Config {
     pub owner: Addr,
     pub anchor_token: Addr,
-    pub anchor_voting_escorw: Addr,
+    pub anchor_voting_escrow: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -308,15 +308,6 @@ fn test_vote_for_single_gauge_by_single_user() {
 
     time += WEEK * (VOTE_DELAY - 1);
 
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "owner".to_string(),
-        ExecuteMsg::CheckpointGauge {
-            addr: "gauge_addr_1".to_string(),
-        },
-        time,
-    );
-
     run_execute_msg_expect_error(
         ContractError::VoteTooOften {},
         deps.as_mut(),
@@ -341,18 +332,9 @@ fn test_vote_for_single_gauge_by_single_user() {
 
     time += WEEK;
 
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "owner".to_string(),
-        ExecuteMsg::CheckpointGauge {
-            addr: "gauge_addr_1".to_string(),
-        },
-        time,
-    );
-
     run_query_msg_expect_ok::<GaugeWeightResponse>(
         GaugeWeightResponse {
-            gauge_weight: Uint128::from(978302798_u64),
+            gauge_weight: Uint128::from(978302799_u64),
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
@@ -373,7 +355,7 @@ fn test_vote_for_single_gauge_by_single_user() {
 
     run_query_msg_expect_ok::<GaugeWeightResponse>(
         GaugeWeightResponse {
-            gauge_weight: Uint128::from(23332_u64),
+            gauge_weight: Uint128::from(23333_u64),
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
@@ -384,18 +366,9 @@ fn test_vote_for_single_gauge_by_single_user() {
 
     time += 100 * WEEK;
 
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "owner".to_string(),
-        ExecuteMsg::CheckpointGauge {
-            addr: "gauge_addr_1".to_string(),
-        },
-        time,
-    );
-
     run_query_msg_expect_ok::<GaugeWeightResponse>(
         GaugeWeightResponse {
-            gauge_weight: Uint128::from(23332_u64),
+            gauge_weight: Uint128::from(23333_u64),
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
@@ -499,26 +472,6 @@ fn test_vote_for_single_gauge_by_multiple_users() {
 
     run_query_msg_expect_ok::<GaugeWeightResponse>(
         GaugeWeightResponse {
-            gauge_weight: Uint128::from(908414277_u64),
-        },
-        deps.as_ref(),
-        QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
-        },
-        time,
-    );
-
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "user_3".to_string(),
-        ExecuteMsg::CheckpointGauge {
-            addr: "gauge_addr_1".to_string(),
-        },
-        time,
-    );
-
-    run_query_msg_expect_ok::<GaugeWeightResponse>(
-        GaugeWeightResponse {
             gauge_weight: Uint128::from(596207044_u64),
         },
         deps.as_ref(),
@@ -529,15 +482,6 @@ fn test_vote_for_single_gauge_by_multiple_users() {
     );
 
     time += 42 * WEEK;
-
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "user_3".to_string(),
-        ExecuteMsg::CheckpointGauge {
-            addr: "gauge_addr_1".to_string(),
-        },
-        time,
-    );
 
     run_query_msg_expect_ok::<GaugeWeightResponse>(
         GaugeWeightResponse {
@@ -551,15 +495,6 @@ fn test_vote_for_single_gauge_by_multiple_users() {
     );
 
     time += 8 * WEEK;
-
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "user_3".to_string(),
-        ExecuteMsg::CheckpointGauge {
-            addr: "gauge_addr_1".to_string(),
-        },
-        time,
-    );
 
     run_query_msg_expect_ok::<GaugeWeightResponse>(
         GaugeWeightResponse {
@@ -657,13 +592,6 @@ fn test_vote_for_multiple_gauges_by_single_user() {
 
     time += 17 * WEEK;
 
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "user_3".to_string(),
-        ExecuteMsg::CheckpointAll {},
-        time,
-    );
-
     run_query_msg_expect_ok::<GaugeRelativeWeightResponse>(
         GaugeRelativeWeightResponse {
             gauge_relative_weight: Decimal::from_ratio(
@@ -679,13 +607,6 @@ fn test_vote_for_multiple_gauges_by_single_user() {
     );
 
     time += 100 * WEEK;
-
-    run_execute_msg_expect_ok(
-        deps.as_mut(),
-        "user_3".to_string(),
-        ExecuteMsg::CheckpointAll {},
-        time,
-    );
 
     run_query_msg_expect_ok::<GaugeRelativeWeightResponse>(
         GaugeRelativeWeightResponse {

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -6,7 +6,8 @@ use crate::utils::{VOTE_DELAY, WEEK};
 
 use anchor_token::gauge_controller::{
     AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
-    GaugeRelativeWeightResponse, GaugeWeightResponse, InstantiateMsg, QueryMsg,
+    GaugeRelativeWeightAtResponse, GaugeRelativeWeightResponse, GaugeWeightAtResponse,
+    GaugeWeightResponse, InstantiateMsg, QueryMsg, TotalWeightAtResponse, TotalWeightResponse,
 };
 
 use cosmwasm_std::testing::{mock_env, mock_info};
@@ -124,6 +125,15 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_ref(),
         QueryMsg::GaugeWeight {
             addr: "gauge_addr_1".to_string(),
+        },
+        time,
+    );
+
+    run_query_msg_expect_error(
+        ContractError::GaugeNotFound {},
+        deps.as_ref(),
+        QueryMsg::GaugeWeight {
+            addr: "gauge_addr_2".to_string(),
         },
         time,
     );
@@ -468,6 +478,18 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         time,
     );
 
+    run_query_msg_expect_ok::<GaugeWeightAtResponse>(
+        GaugeWeightAtResponse {
+            gauge_weight_at: Uint128::from(19956276_u64),
+        },
+        deps.as_ref(),
+        QueryMsg::GaugeWeightAt {
+            addr: "gauge_addr_1".to_string(),
+            time: time + 73 * WEEK,
+        },
+        time,
+    );
+
     time += 23 * WEEK;
 
     run_query_msg_expect_ok::<GaugeWeightResponse>(
@@ -503,6 +525,18 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         deps.as_ref(),
         QueryMsg::GaugeWeight {
             addr: "gauge_addr_1".to_string(),
+        },
+        time,
+    );
+
+    run_query_msg_expect_ok::<GaugeWeightAtResponse>(
+        GaugeWeightAtResponse {
+            gauge_weight_at: Uint128::from(908414277_u64),
+        },
+        deps.as_ref(),
+        QueryMsg::GaugeWeightAt {
+            addr: "gauge_addr_1".to_string(),
+            time: time - 73 * WEEK,
         },
         time,
     );
@@ -590,6 +624,32 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         time,
     );
 
+    run_query_msg_expect_ok::<GaugeRelativeWeightAtResponse>(
+        GaugeRelativeWeightAtResponse {
+            gauge_relative_weight_at: Decimal::from_ratio(
+                Uint128::from(23333_u64),
+                Uint128::from(66666_u64 + 23333_u64),
+            ),
+        },
+        deps.as_ref(),
+        QueryMsg::GaugeRelativeWeightAt {
+            addr: "gauge_addr_1".to_string(),
+            time: time + 117 * WEEK,
+        },
+        time,
+    );
+
+    run_query_msg_expect_ok::<TotalWeightAtResponse>(
+        TotalWeightAtResponse {
+            total_weight_at: Uint128::from(66666_u64 + 23333_u64),
+        },
+        deps.as_ref(),
+        QueryMsg::TotalWeightAt {
+            time: time + 117 * WEEK,
+        },
+        time,
+    );
+
     time += 17 * WEEK;
 
     run_query_msg_expect_ok::<GaugeRelativeWeightResponse>(
@@ -618,6 +678,30 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeight {
             addr: "gauge_addr_1".to_string(),
+        },
+        time,
+    );
+
+    run_query_msg_expect_ok::<TotalWeightResponse>(
+        TotalWeightResponse {
+            total_weight: Uint128::from(66666_u64 + 23333_u64),
+        },
+        deps.as_ref(),
+        QueryMsg::TotalWeight {},
+        time,
+    );
+
+    run_query_msg_expect_ok::<GaugeRelativeWeightAtResponse>(
+        GaugeRelativeWeightAtResponse {
+            gauge_relative_weight_at: Decimal::from_ratio(
+                Uint128::from(434958398_u64),
+                Uint128::from(563375954_u64 + 434958398_u64),
+            ),
+        },
+        deps.as_ref(),
+        QueryMsg::GaugeRelativeWeightAt {
+            addr: "gauge_addr_1".to_string(),
+            time: time - 117 * WEEK,
         },
         time,
     );

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -1,0 +1,143 @@
+use crate::error::ContractError;
+use crate::state::{
+    config_read, config_store, gauge_addr_read, gauge_addr_store, gauge_count_read,
+    gauge_count_store, gauge_info_read, gauge_info_store, gauge_weight_read, gauge_weight_store,
+    Config, GaugeInfo, UserVote, Weight,
+};
+
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    from_binary, to_binary, Binary, CanonicalAddr, Deps, DepsMut, Env, MessageInfo, Response,
+    StdError, Uint128,
+};
+
+use crate::contract::{execute, instantiate, query};
+use anchor_token::gauge_controller::{
+    AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
+    GaugeWeightResponse, InstantiateMsg, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
+};
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+
+#[test]
+fn proper_initialization() {
+    let mut deps = mock_dependencies(&[]);
+
+    let msg = InstantiateMsg {
+        owner: "owner".to_string(),
+        anchor_token: "anchor_token".to_string(),
+        anchor_voting_escorw: "anchor_voting_escrow".to_string(),
+    };
+    let info = mock_info("addr0000", &[]);
+
+    // we can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // it worked, let's query the state
+    let config: ConfigResponse =
+        from_binary(&query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap()).unwrap();
+    assert_eq!("owner", config.owner.as_str());
+    assert_eq!("anchor_token", config.anchor_token.as_str());
+    assert_eq!("anchor_voting_escrow", config.anchor_voting_escorw.as_str());
+}
+
+// test AddGauge, GaugeCount, GaugeWeight, GaugeAddr, AllGaugeAddr
+#[test]
+fn test_add_two_gauges() {
+    let mut deps = mock_dependencies(&[]);
+
+    let msg = InstantiateMsg {
+        owner: "owner".to_string(),
+        anchor_token: "anchor_token".to_string(),
+        anchor_voting_escorw: "anchor_voting_escrow".to_string(),
+    };
+    let info = mock_info("addr0000", &[]);
+
+    // we can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::AddGauge {
+        addr: "gauge_addr_1".to_string(),
+        weight: Uint128::from(100_u64),
+    };
+    let info = mock_info("addr0000", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg.clone());
+
+    match res {
+        Ok(_) => (),
+        _ => panic!("DO NOT ENTER HERE"),
+    }
+
+    let res: GaugeCountResponse =
+        from_binary(&query(deps.as_ref(), mock_env(), QueryMsg::GaugeCount {}).unwrap()).unwrap();
+
+    assert_eq!(1, res.gauge_count);
+
+    let res: GaugeWeightResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::GaugeWeight {
+                addr: "gauge_addr_1".to_string(),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(Uint128::from(100_u64), res.gauge_weight);
+
+    let res: GaugeAddrResponse = from_binary(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::GaugeAddr { gauge_id: 0_u64 },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!("gauge_addr_1".to_string(), res.gauge_addr);
+
+    match query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::GaugeAddr { gauge_id: 1_u64 },
+    ) {
+        Err(ContractError::GaugeNotFound {}) => (),
+        _ => panic!("DO NOT ENTER HERE"),
+    }
+
+    let info = mock_info("addr0000", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg.clone());
+
+    match res {
+        Err(ContractError::GaugeAlreadyExist {}) => (),
+        _ => panic!("DO NOT ENTER HERE"),
+    }
+
+    let msg = ExecuteMsg::AddGauge {
+        addr: "gauge_addr_2".to_string(),
+        weight: Uint128::from(200_u64),
+    };
+    let info = mock_info("addr0000", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg.clone());
+
+    match res {
+        Ok(_) => (),
+        _ => panic!("DO NOT ENTER HERE"),
+    }
+
+    let res: GaugeCountResponse =
+        from_binary(&query(deps.as_ref(), mock_env(), QueryMsg::GaugeCount {}).unwrap()).unwrap();
+
+    assert_eq!(2, res.gauge_count);
+
+    let all_gauge_addr: AllGaugeAddrResponse =
+        from_binary(&query(deps.as_ref(), mock_env(), QueryMsg::AllGaugeAddr {}).unwrap()).unwrap();
+
+    assert_eq!(
+        vec!["gauge_addr_1".to_string(), "gauge_addr_2".to_string()],
+        all_gauge_addr.all_gauge_addr
+    );
+}

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -152,7 +152,7 @@ fn test_add_two_gauges_and_change_weight() {
     );
 
     assert_eq!(
-        ContractError::GaugeAlreadyExist {},
+        ContractError::GaugeAlreadyExists {},
         run_execute_msg_expect_error(
             deps.as_mut(),
             "owner".to_string(),

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -21,7 +21,7 @@ fn proper_initialization() {
     let msg = InstantiateMsg {
         owner: "owner".to_string(),
         anchor_token: "anchor_token".to_string(),
-        anchor_voting_escorw: "anchor_voting_escrow".to_string(),
+        anchor_voting_escrow: "anchor_voting_escrow".to_string(),
     };
     let info = mock_info("addr0000", &[]);
 
@@ -33,7 +33,7 @@ fn proper_initialization() {
         from_binary(&query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap()).unwrap();
     assert_eq!("owner", config.owner.as_str());
     assert_eq!("anchor_token", config.anchor_token.as_str());
-    assert_eq!("anchor_voting_escrow", config.anchor_voting_escorw.as_str());
+    assert_eq!("anchor_voting_escrow", config.anchor_voting_escrow.as_str());
 }
 
 fn run_execute_msg_expect_ok(deps: DepsMut, sender: String, msg: ExecuteMsg, time: u64) {
@@ -94,7 +94,7 @@ fn test_add_two_gauges_and_change_weight() {
         InstantiateMsg {
             owner: "owner".to_string(),
             anchor_token: "anchor_token".to_string(),
-            anchor_voting_escorw: "anchor_voting_escrow".to_string(),
+            anchor_voting_escrow: "anchor_voting_escrow".to_string(),
         },
     )
     .unwrap();
@@ -105,7 +105,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(100_u64),
         },
         time,
@@ -124,7 +124,7 @@ fn test_add_two_gauges_and_change_weight() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -133,7 +133,7 @@ fn test_add_two_gauges_and_change_weight() {
         ContractError::GaugeNotFound {},
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_2".to_string(),
+            gauge_addr: "gauge_addr_2".to_string(),
         },
         time,
     );
@@ -159,7 +159,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(100_u64),
         },
         time,
@@ -170,7 +170,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "addr0000".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_2".to_string(),
+            gauge_addr: "gauge_addr_2".to_string(),
             weight: Uint128::from(100_u64),
         },
         time,
@@ -180,7 +180,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_2".to_string(),
+            gauge_addr: "gauge_addr_2".to_string(),
             weight: Uint128::from(100_u64),
         },
         time,
@@ -207,7 +207,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "addr0000".to_string(),
         ExecuteMsg::ChangeGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(200_u64),
         },
         time,
@@ -218,7 +218,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::ChangeGaugeWeight {
-            addr: "gauge_addr_3".to_string(),
+            gauge_addr: "gauge_addr_3".to_string(),
             weight: Uint128::from(200_u64),
         },
         time,
@@ -228,7 +228,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::ChangeGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(200_u64),
         },
         time,
@@ -240,7 +240,7 @@ fn test_add_two_gauges_and_change_weight() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -251,7 +251,7 @@ fn test_add_two_gauges_and_change_weight() {
         },
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -261,7 +261,7 @@ fn test_add_two_gauges_and_change_weight() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::ChangeGaugeWeight {
-            addr: "gauge_addr_2".to_string(),
+            gauge_addr: "gauge_addr_2".to_string(),
             weight: Uint128::from(200_u64),
         },
         time - WEEK,
@@ -278,7 +278,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         InstantiateMsg {
             owner: "owner".to_string(),
             anchor_token: "anchor_token".to_string(),
-            anchor_voting_escorw: "anchor_voting_escrow".to_string(),
+            anchor_voting_escrow: "anchor_voting_escrow".to_string(),
         },
     )
     .unwrap();
@@ -289,7 +289,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(23333_u64),
         },
         time,
@@ -300,7 +300,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 10001,
         },
         time,
@@ -310,7 +310,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 10000,
         },
         time,
@@ -323,7 +323,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 10000,
         },
         time,
@@ -335,7 +335,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -348,7 +348,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -357,7 +357,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 0,
         },
         time,
@@ -369,7 +369,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -382,7 +382,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -392,7 +392,7 @@ fn test_vote_for_single_gauge_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 10000,
         },
         time,
@@ -409,7 +409,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         InstantiateMsg {
             owner: "owner".to_string(),
             anchor_token: "anchor_token".to_string(),
-            anchor_voting_escorw: "anchor_voting_escrow".to_string(),
+            anchor_voting_escrow: "anchor_voting_escrow".to_string(),
         },
     )
     .unwrap();
@@ -420,7 +420,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(0_u64),
         },
         time,
@@ -430,7 +430,17 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         ContractError::TotalWeightIsZero {},
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
+        },
+        time,
+    );
+
+    run_query_msg_expect_error(
+        ContractError::TotalWeightIsZero {},
+        deps.as_ref(),
+        QueryMsg::GaugeRelativeWeightAt {
+            gauge_addr: "gauge_addr_1".to_string(),
+            time: time + 100 * WEEK,
         },
         time,
     );
@@ -439,7 +449,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::ChangeGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(23333_u64),
         },
         time,
@@ -449,7 +459,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 768,
         },
         time,
@@ -461,7 +471,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         deps.as_mut(),
         "user_2".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 8453,
         },
         time,
@@ -473,7 +483,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -484,7 +494,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeightAt {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             time: time + 73 * WEEK,
         },
         time,
@@ -498,7 +508,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -511,7 +521,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -524,7 +534,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -535,7 +545,7 @@ fn test_vote_for_single_gauge_by_multiple_users() {
         },
         deps.as_ref(),
         QueryMsg::GaugeWeightAt {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             time: time - 73 * WEEK,
         },
         time,
@@ -552,7 +562,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         InstantiateMsg {
             owner: "owner".to_string(),
             anchor_token: "anchor_token".to_string(),
-            anchor_voting_escorw: "anchor_voting_escrow".to_string(),
+            anchor_voting_escrow: "anchor_voting_escrow".to_string(),
         },
     )
     .unwrap();
@@ -563,7 +573,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             weight: Uint128::from(23333_u64),
         },
         time,
@@ -573,7 +583,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         deps.as_mut(),
         "owner".to_string(),
         ExecuteMsg::AddGauge {
-            addr: "gauge_addr_2".to_string(),
+            gauge_addr: "gauge_addr_2".to_string(),
             weight: Uint128::from(66666_u64),
         },
         time,
@@ -583,7 +593,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             ratio: 4357,
         },
         time,
@@ -594,7 +604,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_2".to_string(),
+            gauge_addr: "gauge_addr_2".to_string(),
             ratio: 5644,
         },
         time,
@@ -604,7 +614,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         deps.as_mut(),
         "user_1".to_string(),
         ExecuteMsg::VoteForGaugeWeight {
-            addr: "gauge_addr_2".to_string(),
+            gauge_addr: "gauge_addr_2".to_string(),
             ratio: 5643,
         },
         time,
@@ -619,7 +629,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -633,7 +643,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeightAt {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             time: time + 117 * WEEK,
         },
         time,
@@ -661,7 +671,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -677,7 +687,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeight {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
         },
         time,
     );
@@ -700,7 +710,7 @@ fn test_vote_for_multiple_gauges_by_single_user() {
         },
         deps.as_ref(),
         QueryMsg::GaugeRelativeWeightAt {
-            addr: "gauge_addr_1".to_string(),
+            gauge_addr: "gauge_addr_1".to_string(),
             time: time - 117 * WEEK,
         },
         time,

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -1,11 +1,12 @@
 use crate::error::ContractError;
 
 use crate::contract::{execute, instantiate, query};
+use crate::mock_querier::mock_dependencies;
 use anchor_token::gauge_controller::{
     AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
     GaugeWeightResponse, InstantiateMsg, QueryMsg,
 };
-use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{from_binary, Deps, DepsMut, Uint128};
 use serde::de::DeserializeOwned;
 

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -1,21 +1,11 @@
 use crate::error::ContractError;
-use crate::state::{
-    config_read, config_store, gauge_addr_read, gauge_addr_store, gauge_count_read,
-    gauge_count_store, gauge_info_read, gauge_info_store, gauge_weight_read, gauge_weight_store,
-    Config, GaugeInfo, UserVote, Weight,
-};
 
-#[cfg(not(feature = "library"))]
-use cosmwasm_std::entry_point;
-use cosmwasm_std::{
-    from_binary, to_binary, Binary, CanonicalAddr, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, Uint128,
-};
+use cosmwasm_std::{from_binary, Uint128};
 
 use crate::contract::{execute, instantiate, query};
 use anchor_token::gauge_controller::{
     AllGaugeAddrResponse, ConfigResponse, ExecuteMsg, GaugeAddrResponse, GaugeCountResponse,
-    GaugeWeightResponse, InstantiateMsg, QueryMsg, RelativeWeightResponse, TotalWeightResponse,
+    GaugeWeightResponse, InstantiateMsg, QueryMsg,
 };
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 

--- a/contracts/gauge_controller/src/utils.rs
+++ b/contracts/gauge_controller/src/utils.rs
@@ -94,6 +94,7 @@ pub(crate) fn cancel_scheduled_slope_change(
     if slope.is_zero() {
         return Ok(Response::default());
     }
+
     let key = (addr.clone(), U64Key::new(period));
     if let Some(old_scheduled_slope_change) = SLOPE_CHANGES.may_load(storage, key.clone())? {
         let new_slope = max(old_scheduled_slope_change - slope, Decimal::zero());

--- a/contracts/gauge_controller/src/utils.rs
+++ b/contracts/gauge_controller/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::error::ContractError;
 use crate::state::{
-    GaugeWeight, UserSlopResponse, UserUnlockPeriodResponse, UserVote,
-    VotingEscrowContractQueryMsg, CONFIG, GAUGE_WEIGHT, SLOPE_CHANGES, USER_VOTES,
+    GaugeWeight, UserSlopResponse, UserUnlockPeriodResponse, VotingEscrowContractQueryMsg, CONFIG,
+    GAUGE_WEIGHT, SLOPE_CHANGES,
 };
 
 #[cfg(not(feature = "library"))]
@@ -15,13 +15,13 @@ use cw_storage_plus::{Bound, U64Key};
 use std::cmp::max;
 use std::convert::TryInto;
 
-const DAY: u64 = 24 * 60 * 60;
-const WEEK: u64 = 7 * DAY;
+pub(crate) const DAY: u64 = 24 * 60 * 60;
+pub(crate) const WEEK: u64 = 7 * DAY;
+pub(crate) const VOTE_DELAY: u64 = 2;
 const MAX_PERIOD: u64 = u64::MAX;
-pub const VOTE_DELAY: u64 = 10 * DAY;
 
 pub(crate) fn get_period(seconds: u64) -> u64 {
-    (seconds / WEEK + WEEK) * WEEK
+    seconds / WEEK
 }
 
 pub(crate) fn query_last_user_slope(deps: Deps, user: Addr) -> Result<Decimal, ContractError> {
@@ -48,17 +48,6 @@ pub(crate) fn query_user_unlock_period(deps: Deps, user: Addr) -> Result<u64, Co
             })?,
         }))?
         .unlock_period)
-}
-
-pub(crate) fn fetch_last_user_vote(
-    storage: &dyn Storage,
-    sender: &Addr,
-    addr: &Addr,
-) -> Result<Option<UserVote>, ContractError> {
-    match USER_VOTES.may_load(storage, (sender.clone(), addr.clone())) {
-        Err(_) => Err(ContractError::DeserializationError {}),
-        Ok(result) => Ok(result),
-    }
 }
 
 pub(crate) fn fetch_last_checkpoint(

--- a/contracts/gauge_controller/src/utils.rs
+++ b/contracts/gauge_controller/src/utils.rs
@@ -240,8 +240,8 @@ pub(crate) fn get_gauge_weight_at(
         let scheduled_slope_changes = fetch_slope_changes(storage, addr, old_period, period)?;
 
         for (recalc_period, scheduled_change) in scheduled_slope_changes {
-            assert!(recalc_period > old_period);
             let dt = recalc_period - old_period;
+
             weight = calc_new_weight(weight, dt, scheduled_change)?;
             old_period = recalc_period;
         }

--- a/contracts/gauge_controller/src/utils.rs
+++ b/contracts/gauge_controller/src/utils.rs
@@ -1,0 +1,151 @@
+use crate::error::ContractError;
+use crate::state::{
+    GaugeWeight, UserSlopResponse, UserUnlockPeriodResponse, VotingEscrowContractQueryMsg, CONFIG,
+    GAUGE_WEIGHT, SLOPE_CHANGES, USER_VOTES,
+};
+
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::{
+    to_binary, Addr, Decimal, Deps, Fraction, Order, OverflowError, Pair, QueryRequest, StdResult,
+    Storage, Uint128, Uint256, WasmQuery,
+};
+
+use cw_storage_plus::{Bound, U64Key};
+
+use std::cmp::max;
+use std::convert::TryInto;
+
+const WEEK: u64 = 7 * 24 * 60 * 60;
+const MAX_PERIOD: u64 = u64::MAX;
+
+pub(crate) fn get_period(seconds: u64) -> u64 {
+    (seconds / WEEK + WEEK) * WEEK
+}
+
+pub(crate) fn query_last_user_slope(deps: Deps, user: Addr) -> Result<Decimal, ContractError> {
+    let anchor_voting_escorw = CONFIG.load(deps.storage)?.anchor_voting_escorw;
+    Ok(deps
+        .querier
+        .query::<UserSlopResponse>(&QueryRequest::Wasm(WasmQuery::Smart {
+            contract_addr: anchor_voting_escorw.to_string(),
+            msg: to_binary(&VotingEscrowContractQueryMsg::LastUserSlope {
+                user: user.to_string(),
+            })?,
+        }))?
+        .slope)
+}
+
+pub(crate) fn query_user_unlock_period(deps: Deps, user: Addr) -> Result<u64, ContractError> {
+    let anchor_voting_escorw = CONFIG.load(deps.storage)?.anchor_voting_escorw;
+    Ok(deps
+        .querier
+        .query::<UserUnlockPeriodResponse>(&QueryRequest::Wasm(WasmQuery::Smart {
+            contract_addr: anchor_voting_escorw.to_string(),
+            msg: to_binary(&VotingEscrowContractQueryMsg::UserUnlockPeriod {
+                user: user.to_string(),
+            })?,
+        }))?
+        .unlock_period)
+}
+
+pub(crate) fn fetch_last_checkpoint(
+    storage: &dyn Storage,
+    addr: &Addr,
+) -> Result<Option<Pair<GaugeWeight>>, ContractError> {
+    GAUGE_WEIGHT
+        .prefix(addr.clone())
+        .range(
+            storage,
+            None,
+            Some(Bound::Inclusive(U64Key::new(MAX_PERIOD).wrapped.clone())),
+            Order::Descending,
+        )
+        .next()
+        .transpose()
+        .map_err(|_| ContractError::DeserializationError {})
+}
+
+pub(crate) fn fetch_slope_changes(
+    storage: &dyn Storage,
+    addr: &Addr,
+    from_period: u64,
+    to_period: u64,
+) -> Result<Vec<(u64, Decimal)>, ContractError> {
+    SLOPE_CHANGES
+        .prefix(addr.clone())
+        .range(
+            storage,
+            Some(Bound::Exclusive(U64Key::new(from_period).wrapped)),
+            Some(Bound::Inclusive(U64Key::new(to_period).wrapped)),
+            Order::Ascending,
+        )
+        .map(deserialize_pair::<Decimal>)
+        .collect()
+}
+
+pub(crate) fn deserialize_pair<T>(pair: StdResult<Pair<T>>) -> Result<(u64, T), ContractError> {
+    let (period_serialized, change) = pair?;
+    let period_bytes: [u8; 8] = period_serialized
+        .try_into()
+        .map_err(|_| ContractError::DeserializationError {})?;
+    Ok((u64::from_be_bytes(period_bytes), change))
+}
+
+pub(crate) fn check_if_exists(deps: Deps, addr: &Addr) -> bool {
+    if let Ok(last_checkpoint) = fetch_last_checkpoint(deps.storage, addr) {
+        if let Some(_) = last_checkpoint {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// # Description
+/// Trait is intended for Decimal rounding problem elimination
+trait DecimalRoundedCheckedMul {
+    fn checked_mul(self, other: Uint128) -> Result<Uint128, OverflowError>;
+}
+
+impl DecimalRoundedCheckedMul for Decimal {
+    fn checked_mul(self, other: Uint128) -> Result<Uint128, OverflowError> {
+        if self.is_zero() || other.is_zero() {
+            return Ok(Uint128::zero());
+        }
+        let numerator = other.full_mul(self.numerator());
+        let multiply_ratio = numerator / Uint256::from(self.denominator());
+        if multiply_ratio > Uint256::from(Uint128::MAX) {
+            Err(OverflowError::new(
+                cosmwasm_std::OverflowOperation::Mul,
+                self,
+                other,
+            ))
+        } else {
+            let mut result: Uint128 = multiply_ratio.try_into().unwrap();
+            let rem: Uint128 = numerator
+                .checked_rem(Uint256::from(self.denominator()))
+                .unwrap()
+                .try_into()
+                .unwrap();
+            // 0.5 in Decimal
+            if rem.u128() >= 500000000000000000_u128 {
+                result += Uint128::from(1_u128);
+            }
+            Ok(result)
+        }
+    }
+}
+
+pub(crate) fn calc_new_weight(weight: GaugeWeight, dt: u64, slope_change: Decimal) -> GaugeWeight {
+    GaugeWeight {
+        bias: weight
+            .bias
+            .checked_sub(
+                weight
+                    .slope
+                    .checked_mul(Uint128::from(dt))
+                    .unwrap_or_else(|_| Uint128::zero()),
+            )
+            .unwrap_or_else(|_| Uint128::zero()),
+        slope: max(weight.slope - slope_change, Decimal::zero()),
+    }
+}

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -435,7 +435,7 @@ pub fn assert_new_schedules(
     }
 
     let mut new_counts: BTreeMap<(u64, u64, Uint128), u32> = BTreeMap::new();
-    for schedule in distribution_schedule.clone() {
+    for schedule in distribution_schedule {
         let counter = new_counts.entry(schedule).or_insert(0);
         *counter += 1;
     }

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -44,7 +44,7 @@ pub struct TotalWeightResponse {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct GaugeRelativeWeightResponse {
-    pub relative_weight: Decimal,
+    pub gauge_relative_weight: Decimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -6,27 +6,27 @@ use serde::{Deserialize, Serialize};
 pub struct InstantiateMsg {
     pub owner: String,
     pub anchor_token: String,
-    pub anchor_voting_escorw: String,
+    pub anchor_voting_escrow: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    AddGauge { addr: String, weight: Uint128 },
-    ChangeGaugeWeight { addr: String, weight: Uint128 },
-    VoteForGaugeWeight { addr: String, ratio: u64 },
+    AddGauge { gauge_addr: String, weight: Uint128 },
+    ChangeGaugeWeight { gauge_addr: String, weight: Uint128 },
+    VoteForGaugeWeight { gauge_addr: String, ratio: u64 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     GaugeCount {},
-    GaugeWeight { addr: String },
-    GaugeWeightAt { addr: String, time: u64 },
+    GaugeWeight { gauge_addr: String },
+    GaugeWeightAt { gauge_addr: String, time: u64 },
     TotalWeight {},
     TotalWeightAt { time: u64 },
-    GaugeRelativeWeight { addr: String },
-    GaugeRelativeWeightAt { addr: String, time: u64 },
+    GaugeRelativeWeight { gauge_addr: String },
+    GaugeRelativeWeightAt { gauge_addr: String, time: u64 },
     GaugeAddr { gauge_id: u64 },
     AllGaugeAddr {},
     Config {},
@@ -81,5 +81,5 @@ pub struct AllGaugeAddrResponse {
 pub struct ConfigResponse {
     pub owner: String,
     pub anchor_token: String,
-    pub anchor_voting_escorw: String,
+    pub anchor_voting_escrow: String,
 }

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -32,10 +32,11 @@ pub enum QueryMsg {
     GaugeCount {},
     GaugeWeight { addr: String },
     TotalWeight {},
+
     GaugeAddr { gauge_id: u64 },
     AllGaugeAddr {},
     Config {},
-    RelativeWeight { addr: String, time: Uint128 },
+    GaugeRelativeWeight { addr: String, time: Uint128 },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -1,0 +1,66 @@
+use cosmwasm_std::{Decimal, CanonicalAddr, Uint128};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub voting_escrow_contract: CanonicalAddr,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    AddGauge {
+        addr: CanonicalAddr,
+        weight: Uint128,
+    },
+    ChangeGaugeWeight {
+        addr: CanonicalAddr,
+        weight: Uint128,
+    },
+    VoteForGaugeWeight {
+        addr: CanonicalAddr,
+        user_weight: Uint128,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    GetNGauges {},
+    GetGaugeWeight { addr: CanonicalAddr },
+    GetTotalWeight {},
+    GetGaugeAddr { gauge_id: u64 },
+    GetConfig {},
+    GetRelativeWeight { addr: CanonicalAddr, time: Uint128 },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct GaugeWeightResponse {
+    pub gauge_weight: Uint128
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct TotalWeightResponse {
+    pub total_weight: Uint128
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct RelativeWeightResponse {
+    pub relative_weight: Decimal
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct NGaugesResponse {
+    pub n_gauges: u64
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct GaugeAddrResponse {
+    pub gauge_addr: CanonicalAddr
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub voting_escrow_contract: CanonicalAddr
+}

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -14,7 +14,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     AddGauge { addr: String, weight: Uint128 },
     ChangeGaugeWeight { addr: String, weight: Uint128 },
-    VoteForGaugeWeight { addr: String, voting_ratio: u64 },
+    VoteForGaugeWeight { addr: String, ratio: u64 },
     CheckpointAll {},
     CheckpointGauge { addr: String },
 }

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -15,8 +15,6 @@ pub enum ExecuteMsg {
     AddGauge { addr: String, weight: Uint128 },
     ChangeGaugeWeight { addr: String, weight: Uint128 },
     VoteForGaugeWeight { addr: String, ratio: u64 },
-    CheckpointAll {},
-    CheckpointGauge { addr: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -24,12 +22,14 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     GaugeCount {},
     GaugeWeight { addr: String },
+    GaugeWeightAt { addr: String, time: u64 },
     TotalWeight {},
-
+    TotalWeightAt { time: u64 },
+    GaugeRelativeWeight { addr: String },
+    GaugeRelativeWeightAt { addr: String, time: u64 },
     GaugeAddr { gauge_id: u64 },
     AllGaugeAddr {},
     Config {},
-    GaugeRelativeWeight { addr: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
@@ -38,13 +38,28 @@ pub struct GaugeWeightResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct GaugeWeightAtResponse {
+    pub gauge_weight_at: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct TotalWeightResponse {
     pub total_weight: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct TotalWeightAtResponse {
+    pub total_weight_at: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct GaugeRelativeWeightResponse {
     pub gauge_relative_weight: Decimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct GaugeRelativeWeightAtResponse {
+    pub gauge_relative_weight_at: Decimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -12,18 +12,9 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    AddGauge {
-        addr: String,
-        weight: Uint128,
-    },
-    ChangeGaugeWeight {
-        addr: String,
-        weight: Uint128,
-    },
-    VoteForGaugeWeight {
-        addr: String,
-        user_weight: Uint128,
-    },
+    AddGauge { addr: String, weight: Uint128 },
+    ChangeGaugeWeight { addr: String, weight: Uint128 },
+    VoteForGaugeWeight { addr: String, user_weight: Uint128 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -41,32 +32,32 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct GaugeWeightResponse {
-    pub gauge_weight: Uint128
+    pub gauge_weight: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct TotalWeightResponse {
-    pub total_weight: Uint128
+    pub total_weight: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct RelativeWeightResponse {
-    pub relative_weight: Decimal
+    pub relative_weight: Decimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct GaugeCountResponse {
-    pub gauge_count: u64
+    pub gauge_count: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct GaugeAddrResponse {
-    pub gauge_addr: String
+    pub gauge_addr: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct AllGaugeAddrResponse {
-    pub all_gauge_addr: Vec<String>
+    pub all_gauge_addr: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -1,25 +1,27 @@
-use cosmwasm_std::{Decimal, CanonicalAddr, Uint128};
+use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub voting_escrow_contract: CanonicalAddr,
+    pub owner: String,
+    pub anchor_token: String,
+    pub anchor_voting_escorw: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     AddGauge {
-        addr: CanonicalAddr,
+        addr: String,
         weight: Uint128,
     },
     ChangeGaugeWeight {
-        addr: CanonicalAddr,
+        addr: String,
         weight: Uint128,
     },
     VoteForGaugeWeight {
-        addr: CanonicalAddr,
+        addr: String,
         user_weight: Uint128,
     },
 }
@@ -27,12 +29,13 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    GetNGauges {},
-    GetGaugeWeight { addr: CanonicalAddr },
-    GetTotalWeight {},
-    GetGaugeAddr { gauge_id: u64 },
-    GetConfig {},
-    GetRelativeWeight { addr: CanonicalAddr, time: Uint128 },
+    GaugeCount {},
+    GaugeWeight { addr: String },
+    TotalWeight {},
+    GaugeAddr { gauge_id: u64 },
+    AllGaugeAddr {},
+    Config {},
+    RelativeWeight { addr: String, time: Uint128 },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
@@ -51,16 +54,23 @@ pub struct RelativeWeightResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
-pub struct NGaugesResponse {
-    pub n_gauges: u64
+pub struct GaugeCountResponse {
+    pub gauge_count: u64
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct GaugeAddrResponse {
-    pub gauge_addr: CanonicalAddr
+    pub gauge_addr: String
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct AllGaugeAddrResponse {
+    pub all_gauge_addr: Vec<String>
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
-    pub voting_escrow_contract: CanonicalAddr
+    pub owner: String,
+    pub anchor_token: String,
+    pub anchor_voting_escorw: String,
 }

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -14,7 +14,9 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     AddGauge { addr: String, weight: Uint128 },
     ChangeGaugeWeight { addr: String, weight: Uint128 },
-    VoteForGaugeWeight { addr: String, user_weight: Uint128 },
+    VoteForGaugeWeight { addr: String, voting_ratio: u64 },
+    CheckpointAll {},
+    CheckpointGauge { addr: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -43,7 +43,7 @@ pub struct TotalWeightResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
-pub struct RelativeWeightResponse {
+pub struct GaugeRelativeWeightResponse {
     pub relative_weight: Decimal,
 }
 

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -29,7 +29,7 @@ pub enum QueryMsg {
     GaugeAddr { gauge_id: u64 },
     AllGaugeAddr {},
     Config {},
-    GaugeRelativeWeight { addr: String, time: Uint128 },
+    GaugeRelativeWeight { addr: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/packages/anchor_token/src/lib.rs
+++ b/packages/anchor_token/src/lib.rs
@@ -3,6 +3,7 @@ pub mod collector;
 pub mod common;
 pub mod community;
 pub mod distributor;
+pub mod gauge_controller;
 pub mod gov;
 pub mod querier;
 pub mod staking;


### PR DESCRIPTION
## Summary of changes

This PR creates a new contract to add support for `gauge weights`. These `gauge weights` will be associated with supported collaterals, which will be used to control the ANC distribution to borrowers.

The implementation references [GaugeController](https://github.com/curvefi/curve-dao-contracts/blob/master/contracts/GaugeController.vy) contract of Curve. 

