### PR TITLE
Update the cosmwasm optimizer version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For production builds, run the following:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.11.5
+  cosmwasm/workspace-optimizer:0.12.5
 ```
 
 This performs several optimizations which can significantly reduce the final size of the contract binaries, which will be available inside the `artifacts/` directory.


### PR DESCRIPTION
The old version (0.11.5) cannot compile anymore, saying `feature edition2021 is required`. We can use the newest version (0.12.5) of cosmwasm optimizer to solve the problem.