### PR TITLE
fix: address veANC bugs 1.1

### DIFF
--- a/contracts/gov/src/staking.rs
+++ b/contracts/gov/src/staking.rs
@@ -306,7 +306,7 @@ pub fn withdraw_voting_tokens(
         let user_share = token_manager.share.u128();
 
         let withdraw_share = amount
-            .map(|v| std::cmp::max(v.multiply_ratio(total_share, total_balance).u128(), 1u128))
+            .map(|v| (v.u128() * total_share + total_balance - 1) / total_balance)
             .unwrap_or_else(|| user_share);
         let withdraw_amount = amount
             .map(|v| v.u128())

--- a/contracts/gov/src/staking.rs
+++ b/contracts/gov/src/staking.rs
@@ -49,6 +49,10 @@ pub fn extend_lock_amount(
         amount.multiply_ratio(state.total_share, total_balance)
     };
 
+    if share.is_zero() {
+        return Err(ContractError::InsufficientFunds {});
+    }
+
     token_manager.share += share;
     state.total_share += share;
 

--- a/contracts/gov/src/tests.rs
+++ b/contracts/gov/src/tests.rs
@@ -2102,16 +2102,10 @@ fn withdraw_voting_tokens_remove_not_in_progress_poll_voter_info() {
     mock_instantiate(deps.as_mut());
     mock_register_contracts(deps.as_mut());
 
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(11u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
+    )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: TEST_VOTER.to_string(),
@@ -2274,16 +2268,10 @@ fn fails_withdraw_too_many_tokens() {
     mock_instantiate(deps.as_mut());
     mock_register_contracts(deps.as_mut());
 
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(10u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(10u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(10u128))],
+    )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: TEST_VOTER.to_string(),
@@ -2413,16 +2401,10 @@ fn happy_days_stake_voting_tokens() {
     mock_instantiate(deps.as_mut());
     mock_register_contracts(deps.as_mut());
 
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(11u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
+    )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: TEST_VOTER.to_string(),
@@ -2468,16 +2450,10 @@ fn fails_staking_wrong_token() {
     mock_instantiate(deps.as_mut());
     mock_register_contracts(deps.as_mut());
 
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(11u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
+    )]);
 
     // wrong token
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
@@ -2505,16 +2481,10 @@ fn share_calculation() {
     mock_register_contracts(deps.as_mut());
 
     // create 100 share
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(100u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(100u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(100u128))],
+    )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: TEST_VOTER.to_string(),
@@ -2526,19 +2496,13 @@ fn share_calculation() {
     let _res = execute(deps.as_mut(), mock_env(), info, msg);
 
     // add more balance(100) to make share:balance = 1:2
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(100u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(
-                &MOCK_CONTRACT_ADDR.to_string(),
-                &Uint128::from(200u128 + 100u128),
-            )],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(
+            &MOCK_CONTRACT_ADDR.to_string(),
+            &Uint128::from(200u128 + 100u128),
+        )],
+    )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: TEST_VOTER.to_string(),
@@ -2573,16 +2537,10 @@ fn share_calculation() {
     );
 
     // 100 tokens withdrawn
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(200u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(200u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(200u128))],
+    )]);
 
     let res = query(
         deps.as_ref(),
@@ -4337,16 +4295,10 @@ fn test_deposit_reward_without_in_progress_polls() {
     mock_instantiate(deps.as_mut());
     mock_register_contracts(deps.as_mut());
 
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(11u128))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
+    )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: TEST_VOTER.to_string(),
@@ -4359,16 +4311,10 @@ fn test_deposit_reward_without_in_progress_polls() {
     assert_stake_tokens_result(11, 0, 11, 0, execute_res, deps.as_ref());
 
     // deposit reward
-    deps.querier.with_token_balances(&[
-        (
-            &VOTING_ESCROW.to_string(),
-            &[(&TEST_VOTER.to_string(), &Uint128::from(11_u64))],
-        ),
-        (
-            &VOTING_TOKEN.to_string(),
-            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(17u128))],
-        ),
-    ]);
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(17u128))],
+    )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: TEST_VOTER.to_string(),
@@ -5096,4 +5042,58 @@ fn test_voter_rewards_for_two_voters() {
             attr("amount", "1115"),
         ]
     );
+}
+
+#[test]
+fn test_stake_too_little() {
+    let mut deps = mock_dependencies(&[]);
+    mock_instantiate(deps.as_mut());
+    mock_register_contracts(deps.as_mut());
+
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(10u128))],
+    )]);
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: TEST_VOTER.to_string(),
+        amount: Uint128::from(9u128),
+        msg: to_binary(&Cw20HookMsg::ExtendLockAmount {}).unwrap(),
+    });
+
+    let info = mock_info(VOTING_TOKEN, &[]);
+    let execute_res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_stake_tokens_result(9, 0, 9, 0, execute_res, deps.as_ref());
+
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(11u128))],
+    )]);
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: TEST_VOTER.to_string(),
+        amount: Uint128::from(1u128),
+        msg: to_binary(&Cw20HookMsg::ExtendLockAmount {}).unwrap(),
+    });
+
+    let info = mock_info(VOTING_TOKEN, &[]);
+    assert_eq!(
+        ContractError::InsufficientFunds {},
+        execute(deps.as_mut(), mock_env(), info, msg).unwrap_err()
+    );
+
+    deps.querier.with_token_balances(&[(
+        &VOTING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(12u128))],
+    )]);
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: TEST_VOTER.to_string(),
+        amount: Uint128::from(2u128),
+        msg: to_binary(&Cw20HookMsg::ExtendLockAmount {}).unwrap(),
+    });
+
+    let info = mock_info(VOTING_TOKEN, &[]);
+    let execute_res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_stake_tokens_result(10, 0, 1, 0, execute_res, deps.as_ref());
 }

--- a/contracts/gov/src/tests.rs
+++ b/contracts/gov/src/tests.rs
@@ -4381,7 +4381,7 @@ fn test_deposit_reward_without_in_progress_polls() {
     assert_deposit_reward_result(11, 0, 0, 0, 6, execute_res, deps.as_ref());
 
     let msg = ExecuteMsg::WithdrawVotingTokens {
-        amount: Some(Uint128::from(19u128)),
+        amount: Some(Uint128::from(18u128)),
     };
     let info = mock_info(TEST_VOTER, &[]);
     assert_eq!(
@@ -4773,7 +4773,7 @@ fn test_voter_rewards_for_one_voter() {
     );
 
     let msg = ExecuteMsg::WithdrawVotingTokens {
-        amount: Some(Uint128::from(16u128)),
+        amount: Some(Uint128::from(15u128)),
     };
     let info = mock_info(TEST_VOTER, &[]);
     assert_eq!(
@@ -5039,7 +5039,7 @@ fn test_voter_rewards_for_two_voters() {
     );
 
     let msg = ExecuteMsg::WithdrawVotingTokens {
-        amount: Some(Uint128::from(14u128)),
+        amount: Some(Uint128::from(13u128)),
     };
     let info = mock_info(TEST_VOTER, &[]);
     assert_eq!(

--- a/contracts/voting_escrow/src/contract.rs
+++ b/contracts/voting_escrow/src/contract.rs
@@ -221,6 +221,10 @@ fn extend_lock_time(
         return Err(ContractError::Unauthorized {});
     }
 
+    if Uint128::from(get_period(time)) == Uint128::zero() {
+        return Err(ContractError::ExtendLockTimeTooSmall {});
+    }
+
     let block_period = get_period(env.block.time.seconds());
     let unlock_time;
 

--- a/contracts/voting_escrow/src/error.rs
+++ b/contracts/voting_escrow/src/error.rs
@@ -21,6 +21,9 @@ pub enum ContractError {
     #[error("Lock time must be within the limits")]
     LockTimeLimitsError {},
 
+    #[error("Extend time is too small")]
+    ExtendLockTimeTooSmall {},
+
     #[error("The lock time has not yet expired")]
     LockHasNotExpired {},
 


### PR DESCRIPTION
## Summary of changes

- Ensure `share > 0` when extending lock amount.
- Delete useless token balances declaration in tests.