### PR TITLE
fix: address veANC bugs 1.2

### DIFF
--- a/contracts/gauge_controller/src/contract.rs
+++ b/contracts/gauge_controller/src/contract.rs
@@ -249,7 +249,7 @@ fn vote_for_gauge_weight(
     }
 
     weight.slope = weight.slope + user_slope;
-    weight.bias = weight.bias + user_slope.checked_mul(dt)?;
+    weight.bias += user_slope.checked_mul(dt)?;
 
     schedule_slope_change(deps.storage, &addr, user_slope, user_unlock_period)?;
 

--- a/contracts/gauge_controller/src/mock_querier.rs
+++ b/contracts/gauge_controller/src/mock_querier.rs
@@ -56,7 +56,7 @@ impl WasmMockQuerier {
                     } else if user == *"user_3" {
                         Decimal::from_ratio(Uint128::from(847426363_u64), Uint128::from(100_u64))
                     } else {
-                        panic!("INVALID USER");
+                        Decimal::from_ratio(Uint128::from(101_u64), Uint128::from(100_u64))
                     };
                     SystemResult::Ok(ContractResult::Ok(
                         to_binary(&UserSlopResponse { slope }).unwrap(),
@@ -70,7 +70,7 @@ impl WasmMockQuerier {
                     } else if user == *"user_3" {
                         BASE_TIME + WEEK * 100
                     } else {
-                        panic!("INVALID USER");
+                        BASE_TIME + WEEK
                     };
                     SystemResult::Ok(ContractResult::Ok(
                         to_binary(&UserUnlockPeriodResponse {

--- a/contracts/gauge_controller/src/tests.rs
+++ b/contracts/gauge_controller/src/tests.rs
@@ -1013,3 +1013,180 @@ fn update_config() {
         time,
     );
 }
+
+#[test]
+fn test_vote_decay_faster() {
+    // decay normally
+    let mut deps = mock_dependencies(&[]);
+    let _res = instantiate(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("addr0000", &[]),
+        InstantiateMsg {
+            owner: "owner".to_string(),
+            anchor_token: "anchor_token".to_string(),
+            anchor_voting_escrow: "anchor_voting_escrow".to_string(),
+        },
+    )
+    .unwrap();
+
+    let mut time = BASE_TIME;
+
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "owner".to_string(),
+        ExecuteMsg::AddGauge {
+            gauge_addr: "gauge_addr_1".to_string(),
+            weight: Uint128::from(2000_u64),
+        },
+        time,
+    );
+
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_2".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 5000,
+        },
+        time,
+    );
+
+    let mut gauge_weight_normal = vec![];
+    let mut env = mock_env();
+    for _ in 0..50 {
+        env.block.time = Timestamp::from_seconds(time);
+        let res = query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::GaugeWeight {
+                gauge_addr: "gauge_addr_1".to_string(),
+            },
+        )
+        .unwrap();
+        let gauge_weight: GaugeWeightResponse = from_binary(&res).unwrap();
+        gauge_weight_normal.push(gauge_weight.gauge_weight);
+        time += WEEK;
+    }
+
+    // decay faster
+    let mut deps = mock_dependencies(&[]);
+    let _res = instantiate(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("addr0000", &[]),
+        InstantiateMsg {
+            owner: "owner".to_string(),
+            anchor_token: "anchor_token".to_string(),
+            anchor_voting_escrow: "anchor_voting_escrow".to_string(),
+        },
+    )
+    .unwrap();
+
+    let mut time = BASE_TIME;
+
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "owner".to_string(),
+        ExecuteMsg::AddGauge {
+            gauge_addr: "gauge_addr_1".to_string(),
+            weight: Uint128::from(2000_u64),
+        },
+        time,
+    );
+
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_4".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 2000,
+        },
+        time,
+    );
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_5".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 2000,
+        },
+        time,
+    );
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_6".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 2000,
+        },
+        time,
+    );
+
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_7".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 2000,
+        },
+        time,
+    );
+
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_8".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 2000,
+        },
+        time,
+    );
+
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_9".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 2000,
+        },
+        time,
+    );
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_10".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 2000,
+        },
+        time,
+    );
+    run_execute_msg_expect_ok(
+        deps.as_mut(),
+        "user_2".to_string(),
+        ExecuteMsg::VoteForGaugeWeight {
+            gauge_addr: "gauge_addr_1".to_string(),
+            ratio: 5000,
+        },
+        time,
+    );
+
+    let mut gauge_weight_fast = vec![];
+    let mut env = mock_env();
+    for _ in 0..50 {
+        env.block.time = Timestamp::from_seconds(time);
+        let res = query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::GaugeWeight {
+                gauge_addr: "gauge_addr_1".to_string(),
+            },
+        )
+        .unwrap();
+        let gauge_weight: GaugeWeightResponse = from_binary(&res).unwrap();
+        gauge_weight_fast.push(gauge_weight.gauge_weight);
+        time += WEEK;
+    }
+
+    assert_eq!(gauge_weight_normal, gauge_weight_fast);
+}

--- a/contracts/gov/src/contract.rs
+++ b/contracts/gov/src/contract.rs
@@ -571,7 +571,7 @@ pub fn snapshot_poll(deps: DepsMut, env: Env, poll_id: u64) -> Result<Response, 
     let config: Config = config_read(deps.storage).load()?;
     let mut a_poll: Poll = poll_store(deps.storage).load(&poll_id.to_be_bytes())?;
 
-    if a_poll.status != PollStatus::InProgress {
+    if a_poll.status != PollStatus::InProgress || a_poll.end_height < env.block.height {
         return Err(ContractError::PollNotInProgress {});
     }
 

--- a/contracts/gov/src/contract.rs
+++ b/contracts/gov/src/contract.rs
@@ -216,10 +216,12 @@ pub fn update_config(
         }
 
         if let Some(quorum) = quorum {
+            validate_quorum(quorum)?;
             config.quorum = quorum;
         }
 
         if let Some(threshold) = threshold {
+            validate_threshold(threshold)?;
             config.threshold = threshold;
         }
 


### PR DESCRIPTION
## Summary of changes

- Make sure that the `user_slope` must be `0` when `user_slope.checked_mul(dt) = 0` in `vote_for_gauge_weight`.
- Add validations for `quorum` and `threshold`  in `update_config`.
- Check if `a_poll.end_height >= env.block.height` holds before calculating the `time_to_end` in `snapshot_poll`.
