### PR TITLE
fix: veANC - slope changes can be applied multiple times.

### DIFF
--- a/contracts/voting_escrow/src/checkpoint.rs
+++ b/contracts/voting_escrow/src/checkpoint.rs
@@ -64,7 +64,11 @@ pub(crate) fn checkpoint(
         cancel_scheduled_slope(deps.branch(), point.slope, point.end)?;
 
         // we need to subtract it from total VP slope
-        old_slope = point.slope;
+        old_slope = if point.end > cur_period {
+            point.slope
+        } else {
+            Decimal::zero()
+        };
 
         Point {
             power: current_power + add_voting_power,

--- a/contracts/voting_escrow/src/checkpoint.rs
+++ b/contracts/voting_escrow/src/checkpoint.rs
@@ -63,8 +63,11 @@ pub(crate) fn checkpoint(
         // cancel previously scheduled slope change
         cancel_scheduled_slope(deps.branch(), point.slope, point.end)?;
 
-        // we need to subtract it from total VP slope
-        old_slope = if point.end > cur_period {
+        // we need to subtract it from total VP slope if the slope change hasn't been applied
+        let last_slope_change = LAST_SLOPE_CHANGE
+            .may_load(deps.as_ref().storage)?
+            .unwrap_or(0);
+        old_slope = if point.end > last_slope_change {
             point.slope
         } else {
             Decimal::zero()

--- a/contracts/voting_escrow/src/tests.rs
+++ b/contracts/voting_escrow/src/tests.rs
@@ -1148,7 +1148,7 @@ fn test_slope_changes_be_applied_multiple_times() {
         user: "addr0000".to_string(),
         time: 5160,
     };
-    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
     let user_voting_power: VotingPowerResponse =
         from_binary(&query(deps.as_ref(), env.clone(), QueryMsg::TotalVotingPower {}).unwrap())
@@ -1159,8 +1159,7 @@ fn test_slope_changes_be_applied_multiple_times() {
     env.block.time = Timestamp::from_seconds(env.block.time.seconds() + 2400);
 
     let user_voting_power: VotingPowerResponse =
-        from_binary(&query(deps.as_ref(), env.clone(), QueryMsg::TotalVotingPower {}).unwrap())
-            .unwrap();
+        from_binary(&query(deps.as_ref(), env, QueryMsg::TotalVotingPower {}).unwrap()).unwrap();
 
     assert_eq!(user_voting_power.voting_power, Uint128::from(6944444u128));
 }
@@ -1204,7 +1203,7 @@ fn test_slope_changes_be_applied_multiple_times_2() {
         user: "addr0000".to_string(),
         time: 5160,
     };
-    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
     let user_voting_power: VotingPowerResponse =
         from_binary(&query(deps.as_ref(), env.clone(), QueryMsg::TotalVotingPower {}).unwrap())
@@ -1215,10 +1214,7 @@ fn test_slope_changes_be_applied_multiple_times_2() {
     env.block.time = Timestamp::from_seconds(env.block.time.seconds() + 2400);
 
     let user_voting_power: VotingPowerResponse =
-        from_binary(&query(deps.as_ref(), env.clone(), QueryMsg::TotalVotingPower {}).unwrap())
-            .unwrap();
+        from_binary(&query(deps.as_ref(), env, QueryMsg::TotalVotingPower {}).unwrap()).unwrap();
 
     assert_eq!(user_voting_power.voting_power, Uint128::from(6944444u128));
-
-    // assert!(false);
 }


### PR DESCRIPTION
## Summary of changes

We pass `old_slope` to `checkpoint_total` in `checkpoint` function, which is used to be subtracted from the `point.slope`. However, if the old slope change has already been applied during the process of applying slope changes, it can be subtracted twice. In this PR, we let the `old_slope` be `0` when the old slope change has already been applied.