### PR TITLE
feat: veANC gauge controller voter query

### DIFF
--- a/contracts/gauge_controller/schema/query_msg.json
+++ b/contracts/gauge_controller/schema/query_msg.json
@@ -185,6 +185,26 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "voter"
+      ],
+      "properties": {
+        "voter": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/gauge_controller/src/utils.rs
+++ b/contracts/gauge_controller/src/utils.rs
@@ -25,7 +25,7 @@ pub(crate) fn query_last_user_slope(deps: Deps, user: Addr) -> StdResult<Decimal
     Ok(deps
         .querier
         .query::<UserSlopResponse>(&QueryRequest::Wasm(WasmQuery::Smart {
-            contract_addr: anchor_voting_escrow.to_string(),
+            contract_addr: deps.api.addr_humanize(&anchor_voting_escrow)?.to_string(),
             msg: to_binary(&VotingEscrowContractQueryMsg::LastUserSlope {
                 user: user.to_string(),
             })?,
@@ -38,7 +38,7 @@ pub(crate) fn query_user_unlock_period(deps: Deps, user: Addr) -> StdResult<u64>
     Ok(deps
         .querier
         .query::<UserUnlockPeriodResponse>(&QueryRequest::Wasm(WasmQuery::Smart {
-            contract_addr: anchor_voting_escrow.to_string(),
+            contract_addr: deps.api.addr_humanize(&anchor_voting_escrow)?.to_string(),
             msg: to_binary(&VotingEscrowContractQueryMsg::UserUnlockPeriod {
                 user: user.to_string(),
             })?,

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -47,6 +47,7 @@ pub enum QueryMsg {
     GaugeAddr { gauge_id: u64 },
     AllGaugeAddr {},
     Config {},
+    Voter { address: String }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
@@ -101,6 +102,18 @@ pub struct ConfigResponse {
     pub anchor_voting_escrow: String,
     pub period_duration: u64,
     pub user_vote_delay: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct Vote {
+    pub gauge_addr: String,
+    pub vote_amount: Uint128,
+    pub next_vote_time: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+pub struct VoterResponse {
+    pub votes: Vec<Vote>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/anchor_token/src/gauge_controller.rs
+++ b/packages/anchor_token/src/gauge_controller.rs
@@ -47,7 +47,7 @@ pub enum QueryMsg {
     GaugeAddr { gauge_id: u64 },
     AllGaugeAddr {},
     Config {},
-    Voter { address: String }
+    Voter { address: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]


### PR DESCRIPTION
## Summary of changes

- This PR adds an interface `Voter { address }` for gauge controller, and the response looks like as follow.

```json
{
  [
    {
      "gauge_addr": "terra...",
      "vote_amount": "10000",
      "next_vote_time": 1234567
    },
    {
      "gauge_addr": "terra...",
      "vote_amount": "20000",
      "next_vote_time": 1874567
    }
  ]
}
```

- This PR fixes a contract address format bug.